### PR TITLE
Older docker clients did not allow image names with dashes

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -246,7 +246,7 @@ func (e *ClientExecutor) CreateScratchImage() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	name := fmt.Sprintf("scratch-%s", random)
+	name := fmt.Sprintf("scratch%s", random)
 
 	buf := &bytes.Buffer{}
 	w := tar.NewWriter(buf)


### PR DESCRIPTION
Remove the dash from the generated scratch image name.