### PR TITLE
Add a command line example and support transient mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Future goals include:
 * Port to the newer docker-engine client library
 * Windows support
 
+## Install and Run
+
+```
+$ go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+$ imagebuilder path_to_directory output_image_name
+```
+
 ## Example usage:
 
 ```

--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	dockertypes "github.com/docker/engine-api/types"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+
+	"github.com/openshift/imagebuilder/dockerclient"
+)
+
+func main() {
+	log.SetFlags(0)
+	options := &dockerclient.ClientExecutor{}
+	var dockerfilePath string
+	var mountSpecs stringSliceFlag
+
+	flag.StringVar(&dockerfilePath, "dockerfile", dockerfilePath, "An optional path to a Dockerfile to use.")
+	flag.Var(&mountSpecs, "mount", "An optional list of files and directories to mount during the build. Use SRC:DST syntax for each path.")
+	flag.BoolVar(&options.AllowPull, "allow-pull", true, "Pull the images that are not present.")
+
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) != 2 {
+		log.Fatalf("You must provide two arguments: DIRECTORY and IMAGE_NAME")
+	}
+
+	options.Directory = args[0]
+	options.Tag = args[1]
+	if len(dockerfilePath) == 0 {
+		dockerfilePath = filepath.Join(options.Directory, "Dockerfile")
+	}
+
+	var mounts []dockerclient.Mount
+	for _, s := range mountSpecs {
+		segments := strings.Split(s, ":")
+		if len(segments) != 2 {
+			log.Fatalf("--mount must be of the form SOURCE:DEST")
+		}
+		mounts = append(mounts, dockerclient.Mount{SourcePath: segments[0], DestinationPath: segments[1]})
+	}
+	options.TransientMounts = mounts
+
+	options.Out, options.ErrOut = os.Stdout, os.Stderr
+	options.AuthFn = func(name string) ([]dockertypes.AuthConfig, bool) {
+		return nil, false
+	}
+	options.LogFn = func(format string, args ...interface{}) {
+		if glog.V(2) {
+			log.Printf("Builder: "+format, args...)
+		} else {
+			fmt.Fprintf(options.ErrOut, "--> %s\n", fmt.Sprintf(format, args...))
+		}
+	}
+
+	// Accept ARGS on the command line
+	arguments := make(map[string]string)
+
+	if err := build(dockerfilePath, options, arguments); err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func build(dockerfilePath string, e *dockerclient.ClientExecutor, arguments map[string]string) error {
+	client, err := docker.NewClientFromEnv()
+	if err != nil {
+		log.Fatalf("No connection to Docker available: %v", err)
+	}
+	e.Client = client
+
+	f, err := os.Open(dockerfilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// TODO: handle signals
+	if err := e.Cleanup(); err != nil {
+		fmt.Fprintf(e.ErrOut, "error: Unable to clean up build: %v\n", err)
+	}
+
+	return e.Build(f, arguments)
+}
+
+type stringSliceFlag []string
+
+func (f *stringSliceFlag) Set(s string) error {
+	*f = append(*f, s)
+	return nil
+}
+
+func (f *stringSliceFlag) String() string {
+	return strings.Join(*f, " ")
+}

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/builder/parser"
@@ -21,6 +23,12 @@ import (
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/imageprogress"
 )
+
+// Mount represents a binding between the current system and the destination client
+type Mount struct {
+	SourcePath      string
+	DestinationPath string
+}
 
 // ClientExecutor can run Docker builds from a Docker client.
 type ClientExecutor struct {
@@ -38,6 +46,11 @@ type ClientExecutor struct {
 	// AllowPull when set will pull images that are not present on
 	// the daemon.
 	AllowPull bool
+	// TransientMounts are a set of mounts from outside the build
+	// to the inside that will not be part of the final image. Any
+	// content created inside the mount's destinationPath will be
+	// omitted from the final image.
+	TransientMounts []Mount
 
 	Out, ErrOut io.Writer
 
@@ -128,6 +141,8 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 	e.LogFn("FROM %s", from)
 	glog.V(4).Infof("step: FROM %s", from)
 
+	var sharedMount string
+
 	// create a container to execute in, if necessary
 	mustStart := b.RequiresStart(node)
 	if e.Container == nil {
@@ -137,6 +152,23 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 			},
 		}
 		if mustStart {
+			// Transient mounts only make sense on images that will be running processes
+			if len(e.TransientMounts) > 0 {
+				volumeName, err := randSeq(imageSafeCharacters, 24)
+				if err != nil {
+					return err
+				}
+				v, err := e.Client.CreateVolume(docker.CreateVolumeOptions{Name: volumeName})
+				if err != nil {
+					return err
+				}
+				defer e.cleanupVolume(volumeName)
+				sharedMount = v.Mountpoint
+				opts.HostConfig = &docker.HostConfig{
+					Binds: []string{sharedMount + ":/tmp/__temporarymount"},
+				}
+			}
+
 			// TODO: windows support
 			if len(e.Command) > 0 {
 				opts.Config.Cmd = e.Command
@@ -160,9 +192,40 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 		defer e.Cleanup()
 	}
 
+	// copy any source content into the temporary mount path
+	if mustStart && len(e.TransientMounts) > 0 {
+		var copies []imagebuilder.Copy
+		for i, mount := range e.TransientMounts {
+			source := mount.SourcePath
+			copies = append(copies, imagebuilder.Copy{
+				Src:  source,
+				Dest: []string{path.Join("/tmp/__temporarymount", strconv.Itoa(i))},
+			})
+		}
+		if err := e.Copy(copies...); err != nil {
+			return err
+		}
+	}
+
 	// TODO: lazy start
 	if mustStart && !e.Container.State.Running {
-		if err := e.Client.StartContainer(e.Container.ID, e.HostConfig); err != nil {
+		var hostConfig docker.HostConfig
+		if e.HostConfig != nil {
+			hostConfig = *e.HostConfig
+		}
+
+		// mount individual items temporarily
+		for i, mount := range e.TransientMounts {
+			if len(sharedMount) == 0 {
+				return fmt.Errorf("no mount point available for temporary mounts")
+			}
+			hostConfig.Binds = append(
+				hostConfig.Binds,
+				fmt.Sprintf("%s:%s:%s", path.Join(sharedMount, strconv.Itoa(i)), mount.DestinationPath, "ro"),
+			)
+		}
+
+		if err := e.Client.StartContainer(e.Container.ID, &hostConfig); err != nil {
 			return err
 		}
 		// TODO: is this racy? may have to loop wait in the actual run step
@@ -277,6 +340,11 @@ func randSeq(source string, n int) (string, error) {
 		random[i] = source[random[i]%byte(len(source))]
 	}
 	return string(random), nil
+}
+
+// cleanupVolume attempts to remove the provided volume
+func (e *ClientExecutor) cleanupVolume(name string) error {
+	return e.Client.RemoveVolume(name)
 }
 
 // CleanupImage attempts to remove the provided image.
@@ -451,7 +519,15 @@ func (e *ClientExecutor) Archive(src, dst string, allowDecompression, allowDownl
 			closer = append(closer, func() error { return os.RemoveAll(base) })
 		}
 	} else {
-		base = e.Directory
+		if filepath.IsAbs(src) {
+			base = filepath.Dir(src)
+			src, err = filepath.Rel(base, src)
+			if err != nil {
+				return nil, nil, err
+			}
+		} else {
+			base = e.Directory
+		}
 		infos, err = CalcCopyInfo(src, base, allowDecompression, true)
 	}
 	if err != nil {


### PR DESCRIPTION
Transient mounts exist only for the lifetime of the build and are not
part of the final output image. Specify with `--mounts SRC:DEST` where
SRC is the path on the local filesystem and DEST is the path on the
destination filesystem.