### PR TITLE
Handle unrecognized commands

### DIFF
--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -24,6 +24,7 @@ func main() {
 	flag.StringVar(&dockerfilePath, "dockerfile", dockerfilePath, "An optional path to a Dockerfile to use.")
 	flag.Var(&mountSpecs, "mount", "An optional list of files and directories to mount during the build. Use SRC:DST syntax for each path.")
 	flag.BoolVar(&options.AllowPull, "allow-pull", true, "Pull the images that are not present.")
+	flag.BoolVar(&options.IgnoreUnrecognizedInstructions, "ignore-unrecognized-instructions", true, "If an unrecognized Docker instruction is encountered, warn but do not fail the build.")
 
 	flag.Parse()
 

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -46,6 +46,9 @@ type ClientExecutor struct {
 	// AllowPull when set will pull images that are not present on
 	// the daemon.
 	AllowPull bool
+	// IgnoreUnrecognizedInstructions, if true, allows instructions
+	// that are not yet supported to be ignored (will be printed)
+	IgnoreUnrecognizedInstructions bool
 	// TransientMounts are a set of mounts from outside the build
 	// to the inside that will not be part of the final image. Any
 	// content created inside the mount's destinationPath will be
@@ -413,6 +416,14 @@ func (e *ClientExecutor) LoadImage(from string) (*docker.Image, error) {
 	}
 
 	return e.Client.InspectImage(from)
+}
+
+func (e *ClientExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error {
+	if e.IgnoreUnrecognizedInstructions {
+		e.LogFn("warning: Unknown instruction: %s", strings.ToUpper(step.Command))
+		return nil
+	}
+	return fmt.Errorf("Unknown instruction: %s", strings.ToUpper(step.Command))
 }
 
 // Run executes a single Run command against the current container using exec().

--- a/dockerclient/testdata/Dockerfile.unknown
+++ b/dockerclient/testdata/Dockerfile.unknown
@@ -1,0 +1,4 @@
+FROM busybox
+HEALTH NONE
+SHELL ["/bin/sh", "-c"]
+UNRECOGNIZED


### PR DESCRIPTION
Now that Dockerfile syntax is changing again, tolerate unrecognized
commands by default.