### PR TITLE
Fix transient mounts in Docker 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ To download and install the library and the binary, set up a Golang build enviro
 $ go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
 ```
 
-The included command line takes two arguments, a path to a directory containing a dockerfile, and the name to tag the output image with.
+The included command line takes one argument, a path to a directory containing a Dockerfile. The `-t` option
+can be used to specify an image to tag as.
 
 ```
-$ imagebuilder path_to_directory output_image_name
+$ imagebuilder [-t TAG] DIRECTORY
 ```
 
 To mount a file into the image for build that will not be present in the final output image, run:
@@ -54,7 +55,18 @@ $ imagebuilder --mount ~/secrets/private.key:/etc/keys/private.key path/to/my/co
 
 Any processes in the Dockerfile will have access to `/etc/keys/private.key`, but that file will not be part of the committed image.
 
-Note that running `--mount` requires Docker 1.10 or newer, as it uses a Docker volume to hold the mounted files and the volume API was not available in earlier versions.
+Running `--mount` requires Docker 1.10 or newer, as it uses a Docker volume to hold the mounted files and the volume API was not
+available in earlier versions. In addition, there is currently a bug that blocks Docker 1.12 from using `--mount`.
+
+You can also customize which Dockerfile is run, or run multiple Dockerfiles in sequenc (the FROM is ignored on
+later files):
+
+```
+$ imagebuilder -f Dockerfile:Dockerfile.extra .
+```
+
+will build the current directory and combine the first Dockerfile with the second. The FROM in the second image
+is ignored.
 
 
 ## Code Example

--- a/builder.go
+++ b/builder.go
@@ -3,6 +3,7 @@ package imagebuilder
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -86,7 +87,7 @@ type Builder struct {
 	PendingRuns   []Run
 	PendingCopies []Copy
 
-	Executor Executor
+	//Executor Executor
 }
 
 func NewBuilder() *Builder {
@@ -98,6 +99,25 @@ func NewBuilder() *Builder {
 		Args:        make(map[string]string),
 		AllowedArgs: args,
 	}
+}
+
+func NewBuilderForReader(r io.Reader, args map[string]string) (*Builder, *parser.Node, error) {
+	b := NewBuilder()
+	b.Args = args
+	node, err := ParseDockerfile(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return b, node, err
+}
+
+func NewBuilderForFile(path string, args map[string]string) (*Builder, *parser.Node, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+	return NewBuilderForReader(f, args)
 }
 
 // Step creates a new step from the current state.

--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	log.SetFlags(0)
-	options := &dockerclient.ClientExecutor{}
+	options := dockerclient.NewClientExecutor(nil)
 	var dockerfilePath string
 	var mountSpecs stringSliceFlag
 
@@ -83,7 +83,7 @@ func build(dockerfilePath string, e *dockerclient.ClientExecutor, arguments map[
 	defer f.Close()
 
 	// TODO: handle signals
-	if err := e.Cleanup(); err != nil {
+	if err := e.Cleanup(e.Container); err != nil {
 		fmt.Fprintf(e.ErrOut, "error: Unable to clean up build: %v\n", err)
 	}
 

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/docker/builder/dockerfile/parser"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
 	dockertypes "github.com/docker/engine-api/types"
@@ -78,6 +79,10 @@ type ClientExecutor struct {
 	HostConfig *docker.HostConfig
 	// LogFn is an optional command to log information to the end user
 	LogFn func(format string, args ...interface{})
+
+	// Deferred is a list of operations that must be cleaned up at
+	// the end of execution. Use Release() to handle these.
+	Deferred []func() error
 }
 
 // NewClientExecutor creates a client executor.
@@ -90,31 +95,33 @@ func NewClientExecutor(client *docker.Client) *ClientExecutor {
 	}
 }
 
+func (e *ClientExecutor) DefaultExcludes() error {
+	excludes, err := imagebuilder.ParseDockerignore(e.Directory)
+	if err != nil {
+		return err
+	}
+	e.Excludes = append(excludes, ".dockerignore")
+	return nil
+}
+
 // Build is a helper method to perform a Docker build against the
 // provided Docker client. It will load the image if not specified,
 // create a container if one does not already exist, and start a
 // container if the Dockerfile contains RUN commands. It will cleanup
 // any containers it creates directly, and set the e.Image.ID field
 // to the generated image.
-func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
-	b := imagebuilder.NewBuilder()
-	b.Args = args
-
-	if e.Excludes == nil {
-		excludes, err := imagebuilder.ParseDockerignore(e.Directory)
-		if err != nil {
-			return err
-		}
-		e.Excludes = append(excludes, ".dockerignore")
-	}
-
-	// TODO: check the Docker daemon version (1.20 is required for Upload)
-
-	node, err := imagebuilder.ParseDockerfile(r)
-	if err != nil {
+func (e *ClientExecutor) Build(b *imagebuilder.Builder, node *parser.Node) error {
+	defer e.Release()
+	if err := e.Prepare(b, node); err != nil {
 		return err
 	}
+	if err := e.Execute(b, node); err != nil {
+		return err
+	}
+	return e.Commit(b)
+}
 
+func (e *ClientExecutor) Prepare(b *imagebuilder.Builder, node *parser.Node) error {
 	// identify the base image
 	from, err := b.From(node)
 	if err != nil {
@@ -130,7 +137,7 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 			if err != nil {
 				return fmt.Errorf("unable to create a scratch image for this build: %v", err)
 			}
-			defer e.CleanupImage(from)
+			e.Deferred = append(e.Deferred, func() error { return e.Client.RemoveImage(from) })
 		}
 		glog.V(4).Infof("Retrieving image %q", from)
 		e.Image, err = e.LoadImage(from)
@@ -176,10 +183,10 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 				if err != nil {
 					return fmt.Errorf("unable to create volume to mount secrets: %v", err)
 				}
-				defer e.cleanupVolume(volumeName)
+				e.Deferred = append(e.Deferred, func() error { return e.Client.RemoveVolume(volumeName) })
 				sharedMount = v.Mountpoint
 				opts.HostConfig = &docker.HostConfig{
-					Binds: []string{sharedMount + ":" + e.ContainerTransientMount},
+					Binds: []string{volumeName + ":" + e.ContainerTransientMount},
 				}
 			}
 
@@ -203,7 +210,7 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 			if len(sharedMount) == 0 {
 				return fmt.Errorf("no mount point available for temporary mounts")
 			}
-			binds, err := e.StartPartialContainer(opts, e.TransientMounts, sharedMount)
+			binds, err := e.PopulateTransientMounts(opts, e.TransientMounts, sharedMount)
 			if err != nil {
 				return err
 			}
@@ -215,9 +222,7 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 			return fmt.Errorf("unable to create build container: %v", err)
 		}
 		e.Container = container
-
-		// if we create the container, take responsibilty for cleaning up
-		defer e.Cleanup(container)
+		e.Deferred = append(e.Deferred, func() error { return e.removeContainer(container.ID) })
 	}
 
 	// TODO: lazy start
@@ -225,9 +230,15 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 		if err := e.Client.StartContainer(e.Container.ID, nil); err != nil {
 			return fmt.Errorf("unable to start build container: %v", err)
 		}
+		e.Container.State.Running = true
 		// TODO: is this racy? may have to loop wait in the actual run step
 	}
+	return nil
+}
 
+// Execute performs all of the provided steps against the initialized container. May be
+// invoked multiple times for a given container.
+func (e *ClientExecutor) Execute(b *imagebuilder.Builder, node *parser.Node) error {
 	for _, child := range node.Children {
 		step := b.Step()
 		if err := step.Resolve(child); err != nil {
@@ -242,15 +253,22 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 		}
 	}
 
-	if mustStart {
+	return nil
+}
+
+// Commit saves the completed build as an image with the provided tag. It will
+// stop the container, commit the image, and then remove the container.
+func (e *ClientExecutor) Commit(b *imagebuilder.Builder) error {
+	config := b.Config()
+
+	if e.Container.State.Running {
 		glog.V(4).Infof("Stopping container %s ...", e.Container.ID)
 		if err := e.Client.StopContainer(e.Container.ID, 0); err != nil {
 			return fmt.Errorf("unable to stop build container: %v", err)
 		}
-	}
-
-	config := b.Config()
-	if mustStart {
+		e.Container.State.Running = false
+		// Starting the container may perform escaping of args, so to be consistent
+		// we also set that here
 		config.ArgsEscaped = true
 	}
 
@@ -267,6 +285,8 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 			e.LogFn("Committing changes ...")
 		}
 	}
+
+	defer e.Release()
 
 	image, err := e.Client.CommitContainer(docker.CommitContainerOptions{
 		Author:     b.Author,
@@ -286,45 +306,54 @@ func (e *ClientExecutor) Build(r io.Reader, args map[string]string) error {
 	return nil
 }
 
-func (e *ClientExecutor) StartPartialContainer(opts docker.CreateContainerOptions, transientMounts []Mount, sharedMount string) ([]string, error) {
+func (e *ClientExecutor) PopulateTransientMounts(opts docker.CreateContainerOptions, transientMounts []Mount, sharedMount string) ([]string, error) {
 	container, err := e.Client.CreateContainer(opts)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create build container: %v", err)
+		return nil, fmt.Errorf("unable to create transient container: %v", err)
 	}
-	defer e.Cleanup(container)
+	defer e.removeContainer(container.ID)
 
 	var copies []imagebuilder.Copy
 	for i, mount := range transientMounts {
 		source := mount.SourcePath
 		copies = append(copies, imagebuilder.Copy{
 			Src:  source,
-			Dest: []string{path.Join(e.ContainerTransientMount, strconv.Itoa(i))},
+			Dest: []string{filepath.Join(e.ContainerTransientMount, strconv.Itoa(i))},
 		})
 	}
 	if err := e.CopyContainer(container, copies...); err != nil {
-		return nil, fmt.Errorf("unable to copy build context into container: %v", err)
+		return nil, fmt.Errorf("unable to copy transient context into container: %v", err)
 	}
 
 	// mount individual items temporarily
 	var binds []string
 	for i, mount := range e.TransientMounts {
-		binds = append(binds, fmt.Sprintf("%s:%s:%s", path.Join(sharedMount, strconv.Itoa(i)), mount.DestinationPath, "ro"))
+		binds = append(binds, fmt.Sprintf("%s:%s:%s", filepath.Join(sharedMount, strconv.Itoa(i)), mount.DestinationPath, "ro"))
 	}
 	return binds, nil
 }
 
-// Cleanup will remove the container that created the build.
-func (e *ClientExecutor) Cleanup(container *docker.Container) error {
-	if container == nil {
-		return nil
+// Release deletes any items started by this executor.
+func (e *ClientExecutor) Release() []error {
+	var errs []error
+	for _, fn := range e.Deferred {
+		if err := fn(); err != nil {
+			errs = append(errs, err)
+		}
 	}
+	e.Deferred = nil
+	return errs
+}
+
+// removeContainer removes the provided container ID
+func (e *ClientExecutor) removeContainer(id string) error {
 	err := e.Client.RemoveContainer(docker.RemoveContainerOptions{
-		ID:            container.ID,
+		ID:            id,
 		RemoveVolumes: true,
 		Force:         true,
 	})
 	if _, ok := err.(*docker.NoSuchContainer); err != nil && !ok {
-		return fmt.Errorf("unable to cleanup build container: %v", err)
+		return fmt.Errorf("unable to cleanup container: %v", err)
 	}
 	return nil
 }
@@ -367,16 +396,6 @@ func randSeq(source string, n int) (string, error) {
 		random[i] = source[random[i]%byte(len(source))]
 	}
 	return string(random), nil
-}
-
-// cleanupVolume attempts to remove the provided volume
-func (e *ClientExecutor) cleanupVolume(name string) error {
-	return e.Client.RemoveVolume(name)
-}
-
-// CleanupImage attempts to remove the provided image.
-func (e *ClientExecutor) CleanupImage(name string) error {
-	return e.Client.RemoveImage(name)
 }
 
 // LoadImage checks the client for an image matching from. If not found,
@@ -517,6 +536,7 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, copies ...im
 			if err != nil {
 				return err
 			}
+
 			glog.V(5).Infof("Uploading to %s at %s", container.ID, dst)
 			err = e.Client.UploadToContainer(container.ID, docker.UploadToContainerOptions{
 				InputStream: r,

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -162,7 +162,11 @@ func TestTransientMount(t *testing.T) {
 
 	out := &bytes.Buffer{}
 	e.Out = out
-	if err := e.Build(bytes.NewBufferString("FROM busybox\nRUN ls /mountdir/subdir\nRUN cat /mountfile\n"), nil); err != nil {
+	b, node, err := imagebuilder.NewBuilderForReader(bytes.NewBufferString("FROM busybox\nRUN ls /mountdir/subdir\nRUN cat /mountfile\n"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Build(b, node); err != nil {
 		t.Fatalf("unable to build image: %v", err)
 	}
 	if !strings.Contains(out.String(), "ENV name=value\n") {
@@ -342,7 +346,11 @@ func conformanceTester(t *testing.T, c *docker.Client, test conformanceTest, i i
 			e.Out, e.ErrOut = out, out
 			e.Directory = contextDir
 			e.Tag = nameDirect
-			if err := e.Build(bytes.NewBufferString(testFile), nil); err != nil {
+			b, node, err := imagebuilder.NewBuilderForReader(bytes.NewBufferString(testFile), nil)
+			if err != nil {
+				t.Fatalf("%d: %v", i, err)
+			}
+			if err := e.Build(b, node); err != nil {
 				t.Errorf("%d: failed to build step %d in dockerfile %q: %s\n%s", i, j, dockerfilePath, steps[j].Original, out)
 				break
 			}
@@ -401,7 +409,11 @@ func conformanceTester(t *testing.T, c *docker.Client, test conformanceTest, i i
 		e.Out, e.ErrOut = out, out
 		e.Directory = contextDir
 		e.Tag = nameDirect
-		if err := e.Build(bytes.NewBuffer(data), nil); err != nil {
+		b, node, err := imagebuilder.NewBuilderForReader(bytes.NewBuffer(data), nil)
+		if err != nil {
+			t.Fatalf("%d: %v", i, err)
+		}
+		if err := e.Build(b, node); err != nil {
 			t.Errorf("%d: failed to build complete image in %q: %v\n%s", i, input, err, out)
 		} else {
 			if !equivalentImages(


### PR DESCRIPTION
Use a temporary container instead of hostconfig on start.  Add a test case.

Fixes #6