### PR TITLE
imageprogress: document goroutine leak

### DIFF
--- a/imageprogress/pull.go
+++ b/imageprogress/pull.go
@@ -9,6 +9,8 @@ import (
 // on pull progress of a Docker image. It only reports when the state of the
 // different layers has changed and uses time thresholds to limit the
 // rate of the reports.
+//
+// WARNING: may leak a goroutine, do not use in long-running processes.
 func NewPullWriter(printFn func(string)) io.Writer {
 	return newWriter(pullReporter(printFn), pullLayersChanged)
 }

--- a/imageprogress/push.go
+++ b/imageprogress/push.go
@@ -9,6 +9,8 @@ import (
 // on push progress of a Docker image. It only reports when the state of the
 // different layers has changed and uses time thresholds to limit the
 // rate of the reports.
+//
+// WARNING: may leak a goroutine, do not use in long-running processes.
 func NewPushWriter(printFn func(string)) io.Writer {
 	return newWriter(pushReporter(printFn), pushLayersChanged)
 }


### PR DESCRIPTION
Not 100% sure here but it seems to me that when using the `imageProgress.Write` method, [this for loop](https://github.com/openshift/imagebuilder/blob/86214f339d010b2df2ceb8729f95d3ad2090690b/imageprogress/progress.go#L178) is exited only on error (which may not happen) or on EOF which doesn't happen because the `internalWriter` pipe end is never closed. This results in the goroutine started in `Write` hanging in `decoder.Decode`.

I don't know how to fix it but figured documenting the behavior might save someone some time.