### PR TITLE
Add a flag -strict-volume-ownership which fails if a RUN follows VOLUME

### DIFF
--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -30,6 +30,7 @@ func main() {
 	flag.Var(&mountSpecs, "mount", "An optional list of files and directories to mount during the build. Use SRC:DST syntax for each path.")
 	flag.BoolVar(&options.AllowPull, "allow-pull", true, "Pull the images that are not present.")
 	flag.BoolVar(&options.IgnoreUnrecognizedInstructions, "ignore-unrecognized-instructions", true, "If an unrecognized Docker instruction is encountered, warn but do not fail the build.")
+	flag.BoolVar(&options.StrictVolumeOwnership, "strict-volume-ownership", false, "Due to limitations in docker `cp`, owner permissions on volumes are lost. This flag will fail builds that might fall victim to this.")
 
 	flag.Parse()
 


### PR DESCRIPTION
This prevents accidental loss of data for some images.

Additional guards for #17