### PR TITLE
Build arguments are not being passed to RUN environment

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -188,6 +188,7 @@ func (b *Builder) Step() *Step {
 	dst := make([]string, len(b.Env)+len(b.RunConfig.Env))
 	copy(dst, b.Env)
 	dst = append(dst, b.RunConfig.Env...)
+	dst = append(dst, b.Arguments()...)
 	return &Step{Env: dst}
 }
 
@@ -225,6 +226,7 @@ func (b *Builder) Run(step *Step, exec Executor, noRunsRemaining bool) error {
 	}
 	for _, run := range runs {
 		config := b.Config()
+		config.Env = step.Env
 		if err := exec.Run(run, *config); err != nil {
 			return err
 		}
@@ -406,6 +408,9 @@ func ExportEnv(env []string) string {
 	}
 	out := "export"
 	for _, e := range env {
+		if len(e) == 0 {
+			continue
+		}
 		out += " " + BashQuote(e)
 	}
 	return out + "; "

--- a/builder_test.go
+++ b/builder_test.go
@@ -126,6 +126,7 @@ func (e *testExecutor) UnrecognizedInstruction(step *Step) error {
 
 func TestBuilder(t *testing.T) {
 	testCases := []struct {
+		Args         map[string]string
 		Dockerfile   string
 		From         string
 		Copies       []Copy
@@ -271,6 +272,19 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
+			Dockerfile: "dockerclient/testdata/Dockerfile.args",
+			Args:       map[string]string{"BAR": "first"},
+			From:       "busybox",
+			Config: docker.Config{
+				Image:  "busybox",
+				Env:    []string{"FOO=value", "TEST=", "BAZ=first"},
+				Labels: map[string]string{"test": "value"},
+			},
+			Runs: []Run{
+				{Shell: true, Args: []string{"echo $BAR"}},
+			},
+		},
+		{
 			Dockerfile: "dockerclient/testdata/volume/Dockerfile",
 			From:       "busybox",
 			Image: &docker.Image{
@@ -321,6 +335,7 @@ func TestBuilder(t *testing.T) {
 			continue
 		}
 		b := NewBuilder()
+		b.Args = test.Args
 		from, err := b.From(node)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)

--- a/dockerclient/testdata/Dockerfile.args
+++ b/dockerclient/testdata/Dockerfile.args
@@ -1,0 +1,7 @@
+FROM busybox
+
+ENV FOO="value" TEST=$BAR
+LABEL test="$FOO"
+ARG BAR
+ENV BAZ=$BAR
+RUN echo $BAR


### PR DESCRIPTION
Add a test case that verifies that args are passed through. Note that
Docker 1.13 drops the requirement that args be provided - not
implementing compatibility with that test.