### PR TITLE
cleanup goroutine properly in imageprogress.NewPullWriter

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/imageprogress"
-	"io/ioutil"
 )
 
 // NewClientFromEnv is exposed to simplify getting a client when vendoring this library.
@@ -486,10 +486,13 @@ func (e *ClientExecutor) LoadImage(from string) (*docker.Image, error) {
 	}
 	for _, config := range auth {
 		// TODO: handle IDs?
+		pullWriter := imageprogress.NewPullWriter(outputProgress)
+		defer pullWriter.Close()
+
 		pullImageOptions := docker.PullImageOptions{
 			Repository:    repository,
 			Tag:           tag,
-			OutputStream:  imageprogress.NewPullWriter(outputProgress),
+			OutputStream:  pullWriter,
 			RawJSONStream: true,
 		}
 		if glog.V(5) {

--- a/imageprogress/progress_test.go
+++ b/imageprogress/progress_test.go
@@ -10,10 +10,9 @@ import (
 
 func TestReports(t *testing.T) {
 	tests := []struct {
-		name        string
-		gen         func(*progressGenerator)
-		errExpected bool
-		expected    report
+		name     string
+		gen      func(*progressGenerator)
+		expected report
 	}{
 		{
 			name: "simple report",
@@ -53,12 +52,17 @@ func TestReports(t *testing.T) {
 			},
 		},
 		{
-			name: "detect error",
+			name: "ignore error",
 			gen: func(p *progressGenerator) {
+				p.status("1", "Downloading")
+				p.status("2", "Pull complete")
 				p.status("1", "Downloading")
 				p.err("an error")
 			},
-			errExpected: true,
+			expected: report{
+				statusDownloading: &layerDetail{Count: 1},
+				statusComplete:    &layerDetail{Count: 1},
+			},
 		},
 	}
 
@@ -81,46 +85,12 @@ func TestReports(t *testing.T) {
 		w.(*imageProgressWriter).stableThreshhold = 0
 		_, err := io.Copy(w, pipeIn)
 		if err != nil {
-			if !test.errExpected {
-				t.Errorf("%s: unexpected: %v", test.name, err)
-			}
-			continue
-		}
-		if test.errExpected {
-			t.Errorf("%s: did not get expected error", test.name)
+			t.Errorf("%s: unexpected: %v", test.name, err)
 			continue
 		}
 		if !compareReport(lastReport, test.expected) {
 			t.Errorf("%s: unexpected report, got: %v, expected: %v", test.name, lastReport, test.expected)
 		}
-	}
-}
-
-func TestErrorOnCopy(t *testing.T) {
-	// Producer pipe
-	genIn, genOut := io.Pipe()
-	p := newProgressGenerator(genOut)
-
-	// generate some data
-	go func() {
-		for i := 0; i < 100; i++ {
-			p.status("1", "Downloading")
-			p.status("2", "Downloading")
-			p.status("3", "Downloading")
-		}
-		p.err("data error")
-		genOut.Close()
-	}()
-
-	w := newWriter(func(r report) {}, func(a, b report) bool { return true })
-
-	// Ensure that the error is propagated to the copy
-	_, err := io.Copy(w, genIn)
-	if err == nil {
-		t.Errorf("Did not get an error when copying to writer")
-	}
-	if err.Error() != "data error" {
-		t.Errorf("Did not get expected error: %v", err)
 	}
 }
 
@@ -161,10 +131,10 @@ func TestStableLayerCount(t *testing.T) {
 	for _, test := range tests {
 		w := newWriter(func(report) {}, func(a, b report) bool { return true }).(*imageProgressWriter)
 		w.lastLayerCount = test.lastLayerCount
-		w.layerStatus = map[string]progressLine{}
+		w.layerStatus = map[string]*progressLine{}
 		w.stableThreshhold = test.stableThreshhold
 		for i := 0; i < test.layerStatusCount; i++ {
-			w.layerStatus[strconv.Itoa(i)] = progressLine{}
+			w.layerStatus[strconv.Itoa(i)] = &progressLine{}
 		}
 		var result bool
 		for i := 0; i < test.callCount; i++ {

--- a/imageprogress/pull.go
+++ b/imageprogress/pull.go
@@ -9,7 +9,7 @@ import (
 // on pull progress of a Docker image. It only reports when the state of the
 // different layers has changed and uses time thresholds to limit the
 // rate of the reports.
-func NewPullWriter(printFn func(string)) io.Writer {
+func NewPullWriter(printFn func(string)) io.WriteCloser {
 	return newWriter(pullReporter(printFn), pullLayersChanged)
 }
 

--- a/imageprogress/push.go
+++ b/imageprogress/push.go
@@ -9,7 +9,7 @@ import (
 // on push progress of a Docker image. It only reports when the state of the
 // different layers has changed and uses time thresholds to limit the
 // rate of the reports.
-func NewPushWriter(printFn func(string)) io.Writer {
+func NewPushWriter(printFn func(string)) io.WriteCloser {
 	return newWriter(pushReporter(printFn), pushLayersChanged)
 }
 


### PR DESCRIPTION
- imageProgressWriter should be a WriteCloser, so that a Close() will allow it to clean up its internal goroutine.
- removed error propagation logic because I believe it's not used anywhere, and it's not feasible under the Writer interface contract.
- removed `func (w *imageProgressWriter) ReadFrom` because it's also broken and not actually necessary.
- changed layerStatus from map[string]progressLine to a map[string]*progressLine to save a (small) copy.