### PR TITLE
Handle VOLUME statements referring to missing dirs

### DIFF
--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -349,6 +349,10 @@ func TestConformanceInternal(t *testing.T) {
 			Name:       "noworkdir",
 			Dockerfile: "testdata/Dockerfile.noworkdir",
 		},
+		{
+			Name:       "volumeexists",
+			Dockerfile: "testdata/Dockerfile.volumeexists",
+		},
 	}
 
 	for i, test := range testCases {

--- a/dockerclient/testdata/Dockerfile.volumeexists
+++ b/dockerclient/testdata/Dockerfile.volumeexists
@@ -1,0 +1,5 @@
+FROM busybox
+RUN mkdir -p 0700 /var/lib/bespoke-directory
+RUN chown 1:1 /var/lib/bespoke-directory
+VOLUME /var/lib/bespoke-directory
+RUN touch /var/lib/bespoke-directory/emptyfile


### PR DESCRIPTION
When a VOLUME statement refers to a directory which isn't present in the container (for example, in the Dockerfile that's part of the Docker source tree), our attempts to save and restore its contents will fail.  When attempting to save, detect the 404 error we get for that case and note that the directory should be empty.  When restoring, don't bother trying to extract a snapshot of such a directory, just clean it out.