### PR TITLE
removing "to to" from comments

### DIFF
--- a/shell_parser.go
+++ b/shell_parser.go
@@ -243,7 +243,7 @@ func (sw *shellWord) processDollar() (string, error) {
 			}
 
 			// Grab the current value of the variable in question so we
-			// can use to to determine what to do based on the modifier
+			// can use it to determine what to do based on the modifier
 			newValue := sw.getEnv(name)
 
 			switch modifier {


### PR DESCRIPTION
This is a trivial change. I stumbled upon there 'to to's while using the `oc` command...

This is related to https://github.com/openshift/origin/pull/16715#issuecomment-334707963

Signed-off-by: Christoph Görn <goern@redhat.com>