### PR TITLE
Allow streaming COPY/ADD from an archive on disk

### DIFF
--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -1,0 +1,339 @@
+package dockerclient
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/fileutils"
+	"github.com/golang/glog"
+)
+
+// TransformFileFunc is given a chance to transform an arbitrary input file.
+type TransformFileFunc func(h *tar.Header, r io.Reader) (data []byte, update bool, skip bool, err error)
+
+// FilterArchive transforms the provided input archive to a new archive,
+// giving the fn a chance to transform arbitrary files.
+func FilterArchive(r io.Reader, w io.Writer, fn TransformFileFunc) error {
+	tr := tar.NewReader(r)
+	tw := tar.NewWriter(w)
+
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			return tw.Close()
+		}
+		if err != nil {
+			return err
+		}
+
+		var body io.Reader = tr
+		data, ok, skip, err := fn(h, tr)
+		if err != nil {
+			return err
+		}
+		if skip {
+			continue
+		}
+		if ok {
+			h.Size = int64(len(data))
+			body = bytes.NewBuffer(data)
+		}
+		if err := tw.WriteHeader(h); err != nil {
+			return err
+		}
+		if _, err := io.Copy(tw, body); err != nil {
+			return err
+		}
+	}
+}
+
+type CreateFileFunc func() (*tar.Header, io.ReadCloser, bool, error)
+
+func NewLazyArchive(fn CreateFileFunc) io.ReadCloser {
+	pr, pw := io.Pipe()
+	tw := tar.NewWriter(pw)
+	go func() {
+		for {
+			h, r, more, err := fn()
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			if h == nil {
+				tw.Flush()
+				pw.Close()
+				return
+			}
+			if err := tw.WriteHeader(h); err != nil {
+				r.Close()
+				pw.CloseWithError(err)
+				return
+			}
+			n, err := io.Copy(tw, &io.LimitedReader{R: r, N: h.Size})
+			r.Close()
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			if n != h.Size {
+				pw.CloseWithError(fmt.Errorf("short read for %s", h.Name))
+				return
+			}
+			if !more {
+				tw.Flush()
+				pw.Close()
+				return
+			}
+		}
+	}()
+	return pr
+}
+
+func archiveFromURL(src, dst, tempDir string) (io.Reader, io.Closer, error) {
+	// get filename from URL
+	u, err := url.Parse(src)
+	if err != nil {
+		return nil, nil, err
+	}
+	base := path.Base(u.Path)
+	if base == "." {
+		return nil, nil, fmt.Errorf("cannot determine filename from url: %s", u)
+	}
+	resp, err := http.Get(src)
+	if err != nil {
+		return nil, nil, err
+	}
+	archive := NewLazyArchive(func() (*tar.Header, io.ReadCloser, bool, error) {
+		if resp.StatusCode >= 400 {
+			return nil, nil, false, fmt.Errorf("server returned a status code >= 400: %s", resp.Status)
+		}
+
+		header := &tar.Header{
+			Name: sourceToDestinationName(path.Base(u.Path), dst, false),
+			Mode: 0600,
+		}
+		r := resp.Body
+		if resp.ContentLength == -1 {
+			f, err := ioutil.TempFile(tempDir, "url")
+			if err != nil {
+				return nil, nil, false, fmt.Errorf("unable to create temporary file for source URL: %v", err)
+			}
+			n, err := io.Copy(f, resp.Body)
+			if err != nil {
+				f.Close()
+				return nil, nil, false, fmt.Errorf("unable to download source URL: %v", err)
+			}
+			if err := f.Close(); err != nil {
+				return nil, nil, false, fmt.Errorf("unable to write source URL: %v", err)
+			}
+			f, err = os.Open(f.Name())
+			if err != nil {
+				return nil, nil, false, fmt.Errorf("unable to open downloaded source URL: %v", err)
+			}
+			r = f
+			header.Size = n
+		} else {
+			header.Size = resp.ContentLength
+		}
+		return header, r, false, nil
+	})
+	return archive, closers{resp.Body.Close, archive.Close}, nil
+}
+
+func archiveFromDisk(directory string, src, dst string, allowDownload bool, excludes []string) (io.Reader, io.Closer, error) {
+	var err error
+	if filepath.IsAbs(src) {
+		src, err = filepath.Rel(filepath.Dir(src), src)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	infos, err := CalcCopyInfo(src, directory, true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	options := archiveOptionsFor(infos, dst, excludes)
+
+	glog.V(4).Infof("Tar of directory %s %#v", directory, options)
+	rc, err := archive.TarWithOptions(directory, options)
+	return rc, rc, err
+}
+
+// * -> test
+// a (dir)  -> test
+// a (file) -> test
+// a (dir)  -> test/
+// a (file) -> test/
+//
+func archivePathMapper(src, dst string, isDestDir bool) (fn func(name string, isDir bool) (string, bool)) {
+	srcPattern := filepath.Clean(src)
+	if srcPattern == "." {
+		srcPattern = "*"
+	}
+	pattern := filepath.Base(srcPattern)
+
+	// no wildcards
+	if !containsWildcards(pattern) {
+		return func(name string, isDir bool) (string, bool) {
+			if name == srcPattern {
+				if isDir {
+					return "", false
+				}
+				if isDestDir {
+					return filepath.Join(dst, filepath.Base(name)), true
+				}
+				return dst, true
+			}
+
+			remainder := strings.TrimPrefix(name, srcPattern+string(filepath.Separator))
+			if remainder == name {
+				return "", false
+			}
+			return filepath.Join(dst, remainder), true
+		}
+	}
+
+	// root with pattern
+	prefix := filepath.Dir(srcPattern)
+	if prefix == "." {
+		return func(name string, isDir bool) (string, bool) {
+			// match only on the first segment under the prefix
+			var firstSegment = name
+			if i := strings.Index(name, string(filepath.Separator)); i != -1 {
+				firstSegment = name[:i]
+			}
+			ok, _ := filepath.Match(pattern, firstSegment)
+			if !ok {
+				return "", false
+			}
+			return filepath.Join(dst, name), true
+		}
+	}
+	prefix += string(filepath.Separator)
+
+	// nested with pattern pattern
+	return func(name string, isDir bool) (string, bool) {
+		remainder := strings.TrimPrefix(name, prefix)
+		if remainder == name {
+			return "", false
+		}
+		// match only on the first segment under the prefix
+		var firstSegment = remainder
+		if i := strings.Index(remainder, string(filepath.Separator)); i != -1 {
+			firstSegment = remainder[:i]
+		}
+		ok, _ := filepath.Match(pattern, firstSegment)
+		if !ok {
+			return "", false
+		}
+		return filepath.Join(dst, remainder), true
+	}
+}
+
+func archiveFromFile(file string, src, dst string, excludes []string) (io.Reader, io.Closer, error) {
+	var err error
+	if filepath.IsAbs(src) {
+		src, err = filepath.Rel(filepath.Dir(src), src)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// TODO: multiple sources also require treating dst as a directory
+	isDestDir := strings.HasSuffix(dst, "/") || path.Base(dst) == "."
+	dst = path.Clean(dst)
+	mapperFn := archivePathMapper(src, dst, isDestDir)
+
+	pm, err := fileutils.NewPatternMatcher(excludes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, nil, err
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		in, err := archive.DecompressStream(f)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		err = FilterArchive(in, pw, func(h *tar.Header, r io.Reader) ([]byte, bool, bool, error) {
+			// skip a file if it doesn't match the src
+			isDir := h.Typeflag == tar.TypeDir
+			newName, ok := mapperFn(h.Name, isDir)
+			if !ok {
+				return nil, false, true, err
+			}
+			if newName == "." {
+				return nil, false, true, nil
+			}
+
+			// skip based on excludes
+			if ok, _ := pm.Matches(h.Name); ok {
+				return nil, false, true, nil
+			}
+
+			h.Name = newName
+			// include all files
+			return nil, false, false, nil
+		})
+		pw.CloseWithError(err)
+	}()
+	return pr, closers{f.Close, pr.Close}, nil
+}
+
+func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive.TarOptions {
+	dst = trimLeadingPath(dst)
+	options := &archive.TarOptions{}
+	pm, err := fileutils.NewPatternMatcher(excludes)
+	if err != nil {
+		return options
+	}
+	for _, info := range infos {
+		if ok, _ := pm.Matches(info.Path); ok {
+			continue
+		}
+		options.IncludeFiles = append(options.IncludeFiles, info.Path)
+		if len(dst) == 0 {
+			continue
+		}
+		if options.RebaseNames == nil {
+			options.RebaseNames = make(map[string]string)
+		}
+		if info.FromDir || strings.HasSuffix(dst, "/") || strings.HasSuffix(dst, "/.") || dst == "." {
+			if strings.HasSuffix(info.Path, "/") {
+				options.RebaseNames[info.Path] = dst
+			} else {
+				options.RebaseNames[info.Path] = path.Join(dst, path.Base(info.Path))
+			}
+		} else {
+			options.RebaseNames[info.Path] = dst
+		}
+	}
+	options.ExcludePatterns = excludes
+	return options
+}
+
+func sourceToDestinationName(src, dst string, forceDir bool) string {
+	switch {
+	case forceDir, strings.HasSuffix(dst, "/"), path.Base(dst) == ".":
+		return path.Join(dst, src)
+	default:
+		return dst
+	}
+}

--- a/dockerclient/archive_test.go
+++ b/dockerclient/archive_test.go
@@ -1,0 +1,215 @@
+package dockerclient
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/docker/docker/pkg/archive"
+)
+
+func Test_archiveFromFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "test-tar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, err := archive.TarWithOptions("testdata/dir", &archive.TarOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(f, rc); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	testArchive := f.Name()
+	testCases := []struct {
+		file     string
+		src      string
+		dst      string
+		excludes []string
+		expect   []string
+	}{
+		{
+			file: testArchive,
+			src:  "/*",
+			dst:  "test",
+			expect: []string{
+				"test/Dockerfile",
+				"test/file",
+				"test/subdir",
+				"test/subdir/file2",
+			},
+		},
+		{
+			file: testArchive,
+			src:  ".",
+			dst:  "test",
+			expect: []string{
+				"test/Dockerfile",
+				"test/file",
+				"test/subdir",
+				"test/subdir/file2",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "fil?",
+			dst:  "test",
+			expect: []string{
+				"test/file",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "fil?",
+			dst:  "",
+			expect: []string{
+				"file",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "subdir",
+			dst:  "",
+			expect: []string{
+				"file2",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "subdir/",
+			dst:  "",
+			expect: []string{
+				"file2",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "subdir/",
+			dst:  "test/",
+			expect: []string{
+				"test",
+				"test/file2",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "subdir/file?",
+			dst:  "test/",
+			expect: []string{
+				"test/file2",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "subdi?",
+			dst:  "test",
+			expect: []string{
+				"test/subdir",
+				"test/subdir/file2",
+			},
+		},
+		{
+			file: testArchive,
+			src:  "subdi?",
+			dst:  "test/",
+			expect: []string{
+				"test/subdir",
+				"test/subdir/file2",
+			},
+		},
+		{
+			file:     testArchive,
+			src:      "subdi?",
+			dst:      "test/",
+			excludes: []string{"**/file*"},
+			expect: []string{
+				"test/subdir",
+			},
+		},
+		{
+			file:     testArchive,
+			src:      ".",
+			dst:      "",
+			excludes: []string{"unknown"},
+			expect: []string{
+				"Dockerfile",
+				"file",
+				"subdir",
+				"subdir/file2",
+			},
+		},
+		{
+			file:     testArchive,
+			src:      ".",
+			dst:      "",
+			excludes: []string{"subdir"},
+			expect: []string{
+				"Dockerfile",
+				"file",
+			},
+		},
+		{
+			file:     testArchive,
+			src:      ".",
+			dst:      "",
+			excludes: []string{"file"},
+			expect: []string{
+				"Dockerfile",
+				"subdir",
+				"subdir/file2",
+			},
+		},
+		{
+			file:     testArchive,
+			src:      ".",
+			dst:      "",
+			excludes: []string{"*/file2"},
+			expect: []string{
+				"Dockerfile",
+				"file",
+				"subdir",
+			},
+		},
+	}
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			r, c, err := archiveFromFile(
+				testCase.file,
+				testCase.src,
+				testCase.dst,
+				testCase.excludes,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tr := tar.NewReader(r)
+			var found []string
+			for {
+				h, err := tr.Next()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					t.Fatal(err)
+				}
+				found = append(found, h.Name)
+			}
+			c.Close()
+			sort.Strings(found)
+			if !reflect.DeepEqual(testCase.expect, found) {
+				t.Errorf("unexpected files:\n%v\n%v", testCase.expect, found)
+			}
+		})
+	}
+}

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -16,8 +15,6 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder/dockerfile/parser"
-	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/fileutils"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 
@@ -38,11 +35,19 @@ type Mount struct {
 
 // ClientExecutor can run Docker builds from a Docker client.
 type ClientExecutor struct {
+	// TempDir is the temporary directory to use for storing file
+	// contents. If unset, the default temporary directory for the
+	// system will be used.
+	TempDir string
 	// Client is a client to a Docker daemon.
 	Client *docker.Client
 	// Directory is the context directory to build from, will use
-	// the current working directory if not set.
+	// the current working directory if not set. Ignored if
+	// ContextArchive is set.
 	Directory string
+	// A compressed or uncompressed tar archive that should be used
+	// as the build context.
+	ContextArchive string
 	// Excludes are a list of file patterns that should be excluded
 	// from the context. Will be set to the contents of the
 	// .dockerignore file if nil.
@@ -556,7 +561,7 @@ func (e *ClientExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 	if e.StrictVolumeOwnership && !e.Volumes.Empty() {
 		return fmt.Errorf("a RUN command was executed after a VOLUME command, which may result in ownership information being lost")
 	}
-	if err := e.Volumes.Save(e.Container.ID, e.Client); err != nil {
+	if err := e.Volumes.Save(e.Container.ID, e.TempDir, e.Client); err != nil {
 		return err
 	}
 
@@ -609,7 +614,7 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 		// TODO: reuse source
 		for _, src := range c.Src {
 			glog.V(4).Infof("Archiving %s %t", src, c.Download)
-			r, closer, err := e.Archive(src, c.Dest, c.Download, c.Download, excludes)
+			r, closer, err := e.Archive(src, c.Dest, c.Download, excludes)
 			if err != nil {
 				return err
 			}
@@ -642,74 +647,18 @@ func (c closers) Close() error {
 	return lastErr
 }
 
-func (e *ClientExecutor) Archive(src, dst string, allowDecompression, allowDownload bool, excludes []string) (io.Reader, io.Closer, error) {
-	var closer closers
-	var base string
-	var infos []CopyInfo
-	var err error
+// TODO: this does not support decompressing nested archives for ADD (when the source is a compressed file)
+func (e *ClientExecutor) Archive(src, dst string, allowDownload bool, excludes []string) (io.Reader, io.Closer, error) {
 	if isURL(src) {
 		if !allowDownload {
 			return nil, nil, fmt.Errorf("source can't be a URL")
 		}
-		infos, base, err = DownloadURL(src, dst)
-		if len(base) > 0 {
-			closer = append(closer, func() error { return os.RemoveAll(base) })
-		}
-	} else {
-		if filepath.IsAbs(src) {
-			base = filepath.Dir(src)
-			src, err = filepath.Rel(base, src)
-			if err != nil {
-				return nil, nil, err
-			}
-		} else {
-			base = e.Directory
-		}
-		infos, err = CalcCopyInfo(src, base, allowDecompression, true)
+		return archiveFromURL(src, dst, e.TempDir)
 	}
-	if err != nil {
-		closer.Close()
-		return nil, nil, err
+	if len(e.ContextArchive) > 0 {
+		return archiveFromFile(e.ContextArchive, src, dst, excludes)
 	}
-
-	options := archiveOptionsFor(infos, dst, excludes)
-
-	glog.V(4).Infof("Tar of directory %s %#v", base, options)
-	rc, err := archive.TarWithOptions(base, options)
-	closer = append(closer, rc.Close)
-	return rc, closer, err
-}
-
-func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive.TarOptions {
-	dst = trimLeadingPath(dst)
-	options := &archive.TarOptions{}
-	pm, err := fileutils.NewPatternMatcher(excludes)
-	if err != nil {
-		return options
-	}
-	for _, info := range infos {
-		if ok, _ := pm.Matches(info.Path); ok {
-			continue
-		}
-		options.IncludeFiles = append(options.IncludeFiles, info.Path)
-		if len(dst) == 0 {
-			continue
-		}
-		if options.RebaseNames == nil {
-			options.RebaseNames = make(map[string]string)
-		}
-		if info.FromDir || strings.HasSuffix(dst, "/") || strings.HasSuffix(dst, "/.") || dst == "." {
-			if strings.HasSuffix(info.Path, "/") {
-				options.RebaseNames[info.Path] = dst
-			} else {
-				options.RebaseNames[info.Path] = path.Join(dst, path.Base(info.Path))
-			}
-		} else {
-			options.RebaseNames[info.Path] = dst
-		}
-	}
-	options.ExcludePatterns = excludes
-	return options
+	return archiveFromDisk(e.Directory, src, dst, allowDownload, excludes)
 }
 
 // ContainerVolumeTracker manages tracking archives of specific paths inside a container.
@@ -776,7 +725,7 @@ func (t *ContainerVolumeTracker) Invalidate(path string) {
 
 // Save ensures that all paths tracked underneath this container are archived or
 // returns an error.
-func (t *ContainerVolumeTracker) Save(containerID string, client *docker.Client) error {
+func (t *ContainerVolumeTracker) Save(containerID, tempDir string, client *docker.Client) error {
 	if t == nil {
 		return nil
 	}
@@ -795,7 +744,7 @@ func (t *ContainerVolumeTracker) Save(containerID string, client *docker.Client)
 		if len(archivePath) > 0 {
 			continue
 		}
-		archivePath, err := snapshotPath(dest, containerID, client)
+		archivePath, err := snapshotPath(dest, containerID, tempDir, client)
 		if err != nil {
 			return err
 		}
@@ -829,8 +778,8 @@ func filterTarPipe(w *tar.Writer, r *tar.Reader, fn func(*tar.Header) bool) erro
 
 // snapshotPath preserves the contents of path in container containerID as a temporary
 // archive, returning either an error or the path of the archived file.
-func snapshotPath(path, containerID string, client *docker.Client) (string, error) {
-	f, err := ioutil.TempFile("", "archived-path")
+func snapshotPath(path, containerID, tempDir string, client *docker.Client) (string, error) {
+	f, err := ioutil.TempFile(tempDir, "archived-path")
 	if err != nil {
 		return "", err
 	}

--- a/dockerclient/copyinfo_test.go
+++ b/dockerclient/copyinfo_test.go
@@ -118,7 +118,7 @@ func TestCalcCopyInfo(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		infos, err := CalcCopyInfo(test.origPath, test.rootPath, false, test.allowWildcards)
+		infos, err := CalcCopyInfo(test.origPath, test.rootPath, test.allowWildcards)
 		if !test.errFn(err) {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue


### PR DESCRIPTION
Make the docker client executor capable of streaming the build context
content from a tar archive instead of having to read from disk. This
allows exact permissions to be preserved for unprivileged clients.

Also support setting the temp directory for a build explicitly and add a
test.