### PR TITLE
Add support for passing build args via --build-arg flag

### DIFF
--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -28,7 +28,7 @@ func main() {
 
 	flag.Var(&tags, "t", "The name to assign this image, if any. May be specified multiple times.")
 	flag.Var(&tags, "tag", "The name to assign this image, if any. May be specified multiple times.")
-	flag.Var(&arguments, "build-arg", "An optional list of build-time variables usable as ARG in Dockerfile. Use --build-arg ARG1=VAL1 --build-arg ARG2=VAL2 syntax for passing mutliple build args.")
+	flag.Var(&arguments, "build-arg", "An optional list of build-time variables usable as ARG in Dockerfile. Use --build-arg ARG1=VAL1 --build-arg ARG2=VAL2 syntax for passing multiple build args.")
 	flag.StringVar(&dockerfilePath, "f", dockerfilePath, "An optional path to a Dockerfile to use. You may pass multiple docker files using the operating system delimiter.")
 	flag.StringVar(&dockerfilePath, "file", dockerfilePath, "An optional path to a Dockerfile to use. You may pass multiple docker files using the operating system delimiter.")
 	flag.StringVar(&imageFrom, "from", imageFrom, "An optional FROM to use instead of the one in the Dockerfile.")

--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -24,8 +24,11 @@ func main() {
 	var imageFrom string
 	var mountSpecs stringSliceFlag
 
+	arguments := stringMapFlag{}
+
 	flag.Var(&tags, "t", "The name to assign this image, if any. May be specified multiple times.")
 	flag.Var(&tags, "tag", "The name to assign this image, if any. May be specified multiple times.")
+	flag.Var(&arguments, "build-arg", "An optional list of build-time variables usable as ARG in Dockerfile. Use --build-arg ARG1=VAL1 --build-arg ARG2=VAL2 syntax for passing mutliple build args.")
 	flag.StringVar(&dockerfilePath, "f", dockerfilePath, "An optional path to a Dockerfile to use. You may pass multiple docker files using the operating system delimiter.")
 	flag.StringVar(&dockerfilePath, "file", dockerfilePath, "An optional path to a Dockerfile to use. You may pass multiple docker files using the operating system delimiter.")
 	flag.StringVar(&imageFrom, "from", imageFrom, "An optional FROM to use instead of the one in the Dockerfile.")
@@ -71,9 +74,6 @@ func main() {
 			fmt.Fprintf(options.ErrOut, "--> %s\n", fmt.Sprintf(format, args...))
 		}
 	}
-
-	// Accept ARGS on the command line
-	arguments := make(map[string]string)
 
 	dockerfiles := filepath.SplitList(dockerfilePath)
 	if len(dockerfiles) == 0 {
@@ -136,4 +136,20 @@ func (f *stringSliceFlag) Set(s string) error {
 
 func (f *stringSliceFlag) String() string {
 	return strings.Join(*f, " ")
+}
+
+type stringMapFlag map[string]string
+
+func (f *stringMapFlag) String() string {
+    args := []string{}
+    for k, v := range *f {
+        args = append(args, strings.Join([]string{k, v}, "="))
+    }
+    return strings.Join(args, " ")
+}
+
+func (f *stringMapFlag) Set(value string) error {
+    kv := strings.Split(value, "=")
+    (*f)[kv[0]] = kv[1]
+    return nil
 }


### PR DESCRIPTION
build args had been almost there but a command-line flag to actually pass it to `imagebuilder`.
This commit adds the flag so that `imagebuilder` supports `--build-arg` which populates a value for `ARG` in `Dockerfile`.

Note that there seems like a bit difference between `docker-build` and `imagebuilder` regarding `--build-arg`:

- docker-build is known to leave the build args used while building inside the image metadata
- imagebuilder doesn't leave the build args there

I'm not sure why `imagebuilder`'s implementation doesn't leave build args in image metadata but it seems like a slightly preferable behavior.

`docker-build`'s build args are often used to pass secret variables to a docker-bulid context, which ends up leaving the secrets inside the docker image.
`imagebuilder` users won't be trapped like this due to the different behavior.

```
$ docker build --build-arg foo=bar1 -t buildargtester1 .
Sending build context to Docker daemon  17.63MB
Step 1/4 : FROM alpine:3.7
 ---> 3fd9065eaf02
Step 2/4 : ARG foo
 ---> Using cache
 ---> 6c16d009e365
Step 3/4 : RUN echo $foo > foo.out
 ---> Running in 242096e61485
 ---> 6ef29b90049e
Removing intermediate container 242096e61485
Step 4/4 : RUN cat foo.out
 ---> Running in 2d3895b73aa9
bar1
 ---> 2d76605b424a
Removing intermediate container 2d3895b73aa9
Successfully built 2d76605b424a
Successfully tagged buildargtester1:latest
```

```
$ docker run -it --rm buildargtester1 cat foo.out
bar1
```

```
$ docker inspect buildargtester1 | grep bar1
                "foo=bar1",
```

```
$ ./myimagebuilder --build-arg foo=bar2 -t buildargtester2 .
--> FROM alpine:3.7
--> ARG foo
--> RUN echo $foo > foo.out
--> RUN cat foo.out
bar2
--> Committing changes to buildargtester2 ...
--> Done
```

```
$ docker run -it --rm buildargtester2 cat foo.out
bar2
```

```
$ docker inspect buildargtester2 | grep bar2
```