### PR TITLE
Support multi-stage image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/imagebuilder

--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -20,6 +20,7 @@ func main() {
 	log.SetFlags(0)
 	options := dockerclient.NewClientExecutor(nil)
 	var tags stringSliceFlag
+	var target string
 	var dockerfilePath string
 	var imageFrom string
 	var mountSpecs stringSliceFlag
@@ -29,6 +30,7 @@ func main() {
 	flag.StringVar(&dockerfilePath, "f", dockerfilePath, "An optional path to a Dockerfile to use. You may pass multiple docker files using the operating system delimiter.")
 	flag.StringVar(&dockerfilePath, "file", dockerfilePath, "An optional path to a Dockerfile to use. You may pass multiple docker files using the operating system delimiter.")
 	flag.StringVar(&imageFrom, "from", imageFrom, "An optional FROM to use instead of the one in the Dockerfile.")
+	flag.StringVar(&target, "target", "", "The name of a stage within the Dockerfile to build.")
 	flag.Var(&mountSpecs, "mount", "An optional list of files and directories to mount during the build. Use SRC:DST syntax for each path.")
 	flag.BoolVar(&options.AllowPull, "allow-pull", true, "Pull the images that are not present.")
 	flag.BoolVar(&options.IgnoreUnrecognizedInstructions, "ignore-unrecognized-instructions", true, "If an unrecognized Docker instruction is encountered, warn but do not fail the build.")
@@ -80,12 +82,12 @@ func main() {
 		dockerfiles = []string{filepath.Join(options.Directory, "Dockerfile")}
 	}
 
-	if err := build(dockerfiles[0], dockerfiles[1:], arguments, imageFrom, options); err != nil {
+	if err := build(dockerfiles[0], dockerfiles[1:], arguments, imageFrom, target, options); err != nil {
 		log.Fatal(err.Error())
 	}
 }
 
-func build(dockerfile string, additionalDockerfiles []string, arguments map[string]string, from string, e *dockerclient.ClientExecutor) error {
+func build(dockerfile string, additionalDockerfiles []string, arguments map[string]string, from string, target string, e *dockerclient.ClientExecutor) error {
 	if err := e.DefaultExcludes(); err != nil {
 		return fmt.Errorf("error: Could not parse default .dockerignore: %v", err)
 	}
@@ -103,28 +105,40 @@ func build(dockerfile string, additionalDockerfiles []string, arguments map[stri
 		}
 	}()
 
-	b, node, err := imagebuilder.NewBuilderForFile(dockerfile, arguments)
+	node, err := imagebuilder.ParseFile(dockerfile)
 	if err != nil {
 		return err
 	}
-	if err := e.Prepare(b, node, from); err != nil {
-		return err
-	}
-	if err := e.Execute(b, node); err != nil {
-		return err
-	}
-
 	for _, s := range additionalDockerfiles {
-		_, node, err := imagebuilder.NewBuilderForFile(s, arguments)
+		additionalNode, err := imagebuilder.ParseFile(s)
 		if err != nil {
 			return err
 		}
-		if err := e.Execute(b, node); err != nil {
+		node.Children = append(node.Children, additionalNode.Children...)
+	}
+
+	b := imagebuilder.NewBuilder(arguments)
+	stages := imagebuilder.NewStages(node, b)
+	stages, ok := stages.ByTarget(target)
+	if !ok {
+		return fmt.Errorf("error: The target %q was not found in the provided Dockerfile", target)
+	}
+
+	var stageExecutor *dockerclient.ClientExecutor
+	for i, stage := range stages {
+		stageExecutor = e.WithName(stage.Name)
+		var stageFrom string
+		if i == 0 {
+			stageFrom = from
+		}
+		if err := stageExecutor.Prepare(stage.Builder, stage.Node, stageFrom); err != nil {
+			return err
+		}
+		if err := stageExecutor.Execute(stage.Builder, stage.Node); err != nil {
 			return err
 		}
 	}
-
-	return e.Commit(b)
+	return stageExecutor.Commit(stages[len(stages)-1].Builder)
 }
 
 type stringSliceFlag []string

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -149,7 +149,18 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 	}
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
-	b.PendingCopies = append(b.PendingCopies, Copy{Src: args[0:last], Dest: dest, Download: false})
+	var from string
+	if len(flagArgs) > 0 {
+		for _, arg := range flagArgs {
+			switch {
+			case strings.HasPrefix(arg, "--from="):
+				from = strings.TrimPrefix(arg, "--from=")
+			default:
+				return fmt.Errorf("COPY only supports the --from=<image|stage> flag")
+			}
+		}
+	}
+	b.PendingCopies = append(b.PendingCopies, Copy{From: from, Src: args[0:last], Dest: dest, Download: false})
 	return nil
 }
 
@@ -158,8 +169,12 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 // This sets the image the dockerfile will build on top of.
 //
 func from(b *Builder, args []string, attributes map[string]bool, flagArgs []string, original string) error {
-	if len(args) != 1 {
-		return errExactlyOneArgument("FROM")
+	switch {
+	case len(args) == 1:
+	case len(args) == 3 && len(args[0]) > 0 && args[1] == "as" && len(args[2]) > 0:
+
+	default:
+		return fmt.Errorf("FROM requires either one argument, or three: FROM <source> [as <name>]")
 	}
 
 	name := args[0]

--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -274,6 +274,7 @@ func archiveFromFile(file string, src, dst string, excludes []string) (io.Reader
 			return
 		}
 		err = FilterArchive(in, pw, func(h *tar.Header, r io.Reader) ([]byte, bool, bool, error) {
+			h.Uid, h.Gid = 0, 0
 			// skip a file if it doesn't match the src
 			isDir := h.Typeflag == tar.TypeDir
 			newName, ok := mapperFn(h.Name, isDir)
@@ -296,6 +297,55 @@ func archiveFromFile(file string, src, dst string, excludes []string) (io.Reader
 		pw.CloseWithError(err)
 	}()
 	return pr, closers{f.Close, pr.Close}, nil
+}
+
+func archiveFromContainer(in io.Reader, src, dst string, excludes []string) (io.Reader, io.Closer, error) {
+	// TODO: multiple sources also require treating dst as a directory
+	isDestDir := strings.HasSuffix(dst, "/") || path.Base(dst) == "."
+	dst = path.Clean(dst)
+	mapperFn := archivePathMapper("*", dst, isDestDir)
+
+	pm, err := fileutils.NewPatternMatcher(excludes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var srcName string
+	if !strings.HasSuffix(src, "/") && path.Base(src) != "." {
+		srcName = path.Base(src)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		err = FilterArchive(in, pw, func(h *tar.Header, r io.Reader) ([]byte, bool, bool, error) {
+			isDir := h.Typeflag == tar.TypeDir
+			// special case: container output tar has a single file matching the src name
+			if !isDir && h.Name == srcName && !isDestDir {
+				h.Name = dst
+				return nil, false, false, nil
+			}
+			// skip a file if it doesn't match the src
+			newName, ok := mapperFn(h.Name, isDir)
+			if !ok {
+				return nil, false, true, err
+			}
+			if newName == "." {
+				return nil, false, true, nil
+			}
+
+			// skip based on excludes
+			if ok, _ := pm.Matches(h.Name); ok {
+				return nil, false, true, nil
+			}
+
+			glog.V(5).Infof("Filtering archive %s -> %s", h.Name, newName)
+			h.Name = newName
+			// include all files
+			return nil, false, false, nil
+		})
+		pw.CloseWithError(err)
+	}()
+	return pr, pr, nil
 }
 
 func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive.TarOptions {

--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/golang/glog"
 )
 
@@ -299,7 +300,9 @@ func archiveFromFile(file string, src, dst string, excludes []string) (io.Reader
 
 func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive.TarOptions {
 	dst = trimLeadingPath(dst)
-	options := &archive.TarOptions{}
+	options := &archive.TarOptions{
+		ChownOpts: &idtools.IDPair{UID: 0, GID: 0},
+	}
 	pm, err := fileutils.NewPatternMatcher(excludes)
 	if err != nil {
 		return options

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -62,7 +62,8 @@ func TestMount(t *testing.T) {
 	e.TransientMounts = []Mount{
 		{SourcePath: "testdata/volume/", DestinationPath: "/tmp/test"},
 	}
-	b, node, err := imagebuilder.NewBuilderForFile("testdata/Dockerfile.mount", nil)
+	b := imagebuilder.NewBuilder(nil)
+	node, err := imagebuilder.ParseFile("testdata/Dockerfile.mount")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +240,8 @@ func TestTransientMount(t *testing.T) {
 
 	out := &bytes.Buffer{}
 	e.Out = out
-	b, node, err := imagebuilder.NewBuilderForReader(bytes.NewBufferString("FROM busybox\nRUN ls /mountdir/subdir\nRUN cat /mountfile\n"), nil)
+	b := imagebuilder.NewBuilder(nil)
+	node, err := imagebuilder.ParseDockerfile(bytes.NewBufferString("FROM busybox\nRUN ls /mountdir/subdir\nRUN cat /mountfile\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +361,7 @@ func conformanceTester(t *testing.T, c *docker.Client, test conformanceTest, i i
 		t.Errorf("%d: can't parse Dockerfile %q: %v", i, input, err)
 		return
 	}
-	from, err := imagebuilder.NewBuilder().From(node)
+	from, err := imagebuilder.NewBuilder(nil).From(node)
 	if err != nil {
 		t.Errorf("%d: can't get base FROM %q: %v", i, input, err)
 		return
@@ -423,7 +425,8 @@ func conformanceTester(t *testing.T, c *docker.Client, test conformanceTest, i i
 			e.Out, e.ErrOut = out, out
 			e.Directory = contextDir
 			e.Tag = nameDirect
-			b, node, err := imagebuilder.NewBuilderForReader(bytes.NewBufferString(testFile), test.Args)
+			b := imagebuilder.NewBuilder(test.Args)
+			node, err := imagebuilder.ParseDockerfile(bytes.NewBufferString(testFile))
 			if err != nil {
 				t.Fatalf("%d: %v", i, err)
 			}
@@ -491,7 +494,8 @@ func conformanceTester(t *testing.T, c *docker.Client, test conformanceTest, i i
 		e.Out, e.ErrOut = out, out
 		e.Directory = contextDir
 		e.Tag = nameDirect
-		b, node, err := imagebuilder.NewBuilderForReader(bytes.NewBuffer(data), test.Args)
+		b := imagebuilder.NewBuilder(test.Args)
+		node, err := imagebuilder.ParseDockerfile(bytes.NewBuffer(data))
 		if err != nil {
 			t.Fatalf("%d: %v", i, err)
 		}

--- a/dockerclient/testdata/multistage/Dockerfile
+++ b/dockerclient/testdata/multistage/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.9 as builder
+WORKDIR /tmp
+COPY . .
+RUN echo foo > /tmp/bar
+
+FROM busybox:latest
+WORKDIR /
+COPY --from=builder /tmp/bar /bin/baz
+COPY dir /var/dir
+
+RUN echo /bin/baz
+

--- a/dockerclient/testdata/multistage/Dockerfile.ref
+++ b/dockerclient/testdata/multistage/Dockerfile.ref
@@ -1,0 +1,6 @@
+FROM busybox:latest
+WORKDIR /
+COPY --from=nginx:latest /etc/nginx/nginx.conf /var/tmp/
+COPY dir /var/dir
+RUN cat /var/tmp/nginx.conf
+


### PR DESCRIPTION
Adds support for the `FROM foo AS bar` and `COPY --from=bar` syntax,
    allowing multi-stage builds to be executed. The `-target` flag is supported
    on `cmd/imagebuilder` to allow a specific stage to be chosen.