### PR TITLE
RUN statements with JSON arrays were not correct

### DIFF
--- a/dockerclient/testdata/Dockerfile.run.args
+++ b/dockerclient/testdata/Dockerfile.run.args
@@ -1,0 +1,5 @@
+FROM busybox
+RUN echo first second
+RUN /bin/echo third fourth
+RUN ["/bin/echo", "fifth", "sixth"]
+RUN ["/bin/sh", "-c", "echo inner $1", "", "outer"]


### PR DESCRIPTION
The `RUN ["cmd", "arg", "arg"]` must be handled by combining the
existing environment and working dir code with the shell to execute the
correct child.

Newer versions of docker accept both working dir and environment and a
future change would leverage those.