### PR TITLE
add NoAuthFn to make imagebuilder vendorable

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -113,6 +113,11 @@ type ClientExecutor struct {
 	Volumes *ContainerVolumeTracker
 }
 
+// NotAuthFn can be used for AuthFn when no authentication is required in Docker.
+func NoAuthFn(string) ([]dockertypes.AuthConfig, bool) {
+	return nil, false
+}
+
 // NewClientExecutor creates a client executor.
 func NewClientExecutor(client *docker.Client) *ClientExecutor {
 	return &ClientExecutor{


### PR DESCRIPTION
@smarterclayton we need this otherwise you will never be able to initialize the AuthFn outside this repo (vendored types).