### PR TITLE
When building multiple stages, use a previous container

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -141,13 +141,22 @@ var (
 
 type Stages []Stage
 
+func (stages Stages) ByName(name string) (Stage, bool) {
+	for _, stage := range stages {
+		if stage.Name == name {
+			return stage, true
+		}
+	}
+	return Stage{}, false
+}
+
 func (stages Stages) ByTarget(target string) (Stages, bool) {
 	if len(target) == 0 {
 		return stages, true
 	}
 	for i, stage := range stages {
 		if stage.Name == target {
-			return stages[:i+1], true
+			return stages[i : i+1], true
 		}
 	}
 	return nil, false

--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -133,21 +133,12 @@ func build(dockerfile string, additionalDockerfiles []string, arguments map[stri
 		return fmt.Errorf("error: The target %q was not found in the provided Dockerfile", target)
 	}
 
-	var stageExecutor *dockerclient.ClientExecutor
-	for i, stage := range stages {
-		stageExecutor = e.WithName(stage.Name)
-		var stageFrom string
-		if i == 0 {
-			stageFrom = from
-		}
-		if err := stageExecutor.Prepare(stage.Builder, stage.Node, stageFrom); err != nil {
-			return err
-		}
-		if err := stageExecutor.Execute(stage.Builder, stage.Node); err != nil {
-			return err
-		}
+	lastExecutor, err := e.Stages(b, stages, from)
+	if err != nil {
+		return err
 	}
-	return stageExecutor.Commit(stages[len(stages)-1].Builder)
+
+	return lastExecutor.Commit(stages[len(stages)-1].Builder)
 }
 
 type stringSliceFlag []string

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -161,6 +161,45 @@ func (e *ClientExecutor) WithName(name string) *ClientExecutor {
 	return child
 }
 
+// Stages executes all of the provided stages, starting from the base image. It returns the executor of the last stage
+// or an error if a stage fails.
+func (e *ClientExecutor) Stages(b *imagebuilder.Builder, stages imagebuilder.Stages, from string) (*ClientExecutor, error) {
+	var stageExecutor *ClientExecutor
+	for i, stage := range stages {
+		stageExecutor = e.WithName(stage.Name)
+
+		var stageFrom string
+		if i == 0 {
+			stageFrom = from
+		} else {
+			from, err := b.From(stage.Node)
+			if err != nil {
+				return nil, err
+			}
+			if prereq := e.Named[from]; prereq != nil {
+				b, ok := stages.ByName(from)
+				if !ok {
+					return nil, fmt.Errorf("error: Unable to find stage %s builder", from)
+				}
+				stageExecutor.Image = &docker.Image{
+					Config: b.Builder.Config(),
+				}
+				stageExecutor.Container = prereq.Container
+				glog.V(4).Infof("Using previous stage %s as image: %#v", from, stageExecutor.Image.Config)
+			}
+			stageFrom = from
+		}
+
+		if err := stageExecutor.Prepare(stage.Builder, stage.Node, stageFrom); err != nil {
+			return nil, err
+		}
+		if err := stageExecutor.Execute(stage.Builder, stage.Node); err != nil {
+			return nil, err
+		}
+	}
+	return stageExecutor, nil
+}
+
 // Build is a helper method to perform a Docker build against the
 // provided Docker client. It will load the image if not specified,
 // create a container if one does not already exist, and start a
@@ -188,6 +227,7 @@ func (e *ClientExecutor) Prepare(b *imagebuilder.Builder, node *parser.Node, fro
 			return err
 		}
 	}
+
 	// load the image
 	if e.Image == nil {
 		if from == imagebuilder.NoBaseImageSpecifier {

--- a/dockerclient/testdata/Dockerfile.reusebase
+++ b/dockerclient/testdata/Dockerfile.reusebase
@@ -1,0 +1,6 @@
+FROM centos:7 AS base
+RUN touch /1
+ENV LOCAL=/1
+
+FROM base
+RUN find $LOCAL


### PR DESCRIPTION
Later stages of a multi-stage build should use previous stage containers
when the FROM matches an AS.