### PR TITLE
Handle copy destination with single dot properly

### DIFF
--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -1,0 +1,35 @@
+package imagebuilder
+
+import (
+	"reflect"
+	"testing"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+func TestDispatchCopy(t *testing.T) {
+	mybuilder := Builder{
+		RunConfig: docker.Config{
+			WorkingDir: "/root",
+			Cmd:        []string{"/bin/sh"},
+			Image:      "alpine",
+		},
+	}
+	args := []string{"/go/src/github.com/kubernetes-incubator/service-catalog/controller-manager", "."}
+	flagArgs := []string{"--from=builder"}
+	original := "COPY --from=builder /go/src/github.com/kubernetes-incubator/service-catalog/controller-manager ."
+	if err := dispatchCopy(&mybuilder, args, nil, flagArgs, original); err != nil {
+		t.Errorf("dispatchCopy error: %v", err)
+	}
+	expectedPendingCopies := []Copy{
+		{
+			From:     "builder",
+			Src:      []string{"/go/src/github.com/kubernetes-incubator/service-catalog/controller-manager"},
+			Dest:     "/root/", // destination must contain a trailing slash
+			Download: false,
+		},
+	}
+	if !reflect.DeepEqual(mybuilder.PendingCopies, expectedPendingCopies) {
+		t.Errorf("Expected %v, got %v\n", expectedPendingCopies, mybuilder.PendingCopies)
+	}
+}

--- a/internals.go
+++ b/internals.go
@@ -46,12 +46,23 @@ func handleJSONArgs(args []string, attributes map[string]bool) []string {
 	return []string{strings.Join(args, " ")}
 }
 
+func hasSlash(input string) bool {
+	return strings.HasSuffix(input, string(os.PathSeparator)) || strings.HasSuffix(input, string(os.PathSeparator)+".")
+}
+
 // makeAbsolute ensures that the provided path is absolute.
 func makeAbsolute(dest, workingDir string) string {
 	// Twiddle the destination when its a relative path - meaning, make it
 	// relative to the WORKINGDIR
+	if dest == "." {
+		if !hasSlash(workingDir) {
+			workingDir += string(os.PathSeparator)
+		}
+		dest = workingDir
+	}
+
 	if !filepath.IsAbs(dest) {
-		hasSlash := strings.HasSuffix(dest, string(os.PathSeparator)) || strings.HasSuffix(dest, string(os.PathSeparator)+".")
+		hasSlash := hasSlash(dest)
 		dest = filepath.Join(string(os.PathSeparator), filepath.FromSlash(workingDir), dest)
 
 		// Make sure we preserve any trailing slash


### PR DESCRIPTION
A copy operation with a destination of "." was not taking into account the
working directory properly, resulting in the working dir becoming the
destination. Essentially when a destination is ".", the working directory is
what needs to be checked for proper prefixes and suffixes.

For reference the dockerfile snippet I was testing with looked like:

...
FROM scratch
WORKDIR /root/
COPY --from=builder /go/src/github.com/jpeeler/podpreset-crd/controller-manager .
ENTRYPOINT ["./controller-manager"]
CMD ["--install-crds=false"]