### PR TITLE
`COPY --from=` did not properly handle wildcards

### DIFF
--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -260,12 +260,7 @@ func archiveFromFile(file string, src, dst string, excludes []string) (io.Reader
 		}
 	}
 
-	// TODO: multiple sources also require treating dst as a directory
-	isDestDir := strings.HasSuffix(dst, "/") || path.Base(dst) == "."
-	dst = path.Clean(dst)
-	mapperFn := archivePathMapper(src, dst, isDestDir)
-
-	pm, err := fileutils.NewPatternMatcher(excludes)
+	mapper, _, err := newArchiveMapper(src, dst, excludes, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -274,86 +269,115 @@ func archiveFromFile(file string, src, dst string, excludes []string) (io.Reader
 	if err != nil {
 		return nil, nil, err
 	}
-	pr, pw := io.Pipe()
-	go func() {
-		in, err := archive.DecompressStream(f)
-		if err != nil {
-			pw.CloseWithError(err)
-			return
-		}
-		err = FilterArchive(in, pw, func(h *tar.Header, r io.Reader) ([]byte, bool, bool, error) {
-			h.Uid, h.Gid = 0, 0
-			// skip a file if it doesn't match the src
-			isDir := h.Typeflag == tar.TypeDir
-			newName, ok := mapperFn(h.Name, isDir)
-			if !ok {
-				return nil, false, true, err
-			}
-			if newName == "." {
-				return nil, false, true, nil
-			}
 
-			// skip based on excludes
-			if ok, _ := pm.Matches(h.Name); ok {
-				return nil, false, true, nil
-			}
-
-			h.Name = newName
-			// include all files
-			return nil, false, false, nil
-		})
-		pw.CloseWithError(err)
-	}()
-	return pr, closers{f.Close, pr.Close}, nil
+	r, err := transformArchive(f, true, mapper.Filter)
+	return r, f, err
 }
 
-func archiveFromContainer(in io.Reader, src, dst string, excludes []string) (io.Reader, io.Closer, error) {
-	// TODO: multiple sources also require treating dst as a directory
-	isDestDir := strings.HasSuffix(dst, "/") || path.Base(dst) == "."
-	dst = path.Clean(dst)
-	mapperFn := archivePathMapper("*", dst, isDestDir)
-
-	pm, err := fileutils.NewPatternMatcher(excludes)
+func archiveFromContainer(in io.Reader, src, dst string, excludes []string) (io.Reader, string, error) {
+	mapper, archiveRoot, err := newArchiveMapper(src, dst, excludes, true)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 
-	var srcName string
-	if !strings.HasSuffix(src, "/") && path.Base(src) != "." {
-		srcName = path.Base(src)
-	}
+	r, err := transformArchive(in, false, mapper.Filter)
+	return r, archiveRoot, err
+}
 
+func transformArchive(r io.Reader, compressed bool, fn TransformFileFunc) (io.Reader, error) {
 	pr, pw := io.Pipe()
 	go func() {
-		err = FilterArchive(in, pw, func(h *tar.Header, r io.Reader) ([]byte, bool, bool, error) {
-			isDir := h.Typeflag == tar.TypeDir
-			// special case: container output tar has a single file matching the src name
-			if !isDir && h.Name == srcName && !isDestDir {
-				h.Name = dst
-				return nil, false, false, nil
+		if compressed {
+			in, err := archive.DecompressStream(r)
+			if err != nil {
+				pw.CloseWithError(err)
+				return
 			}
-			// skip a file if it doesn't match the src
-			newName, ok := mapperFn(h.Name, isDir)
-			if !ok {
-				return nil, false, true, err
-			}
-			if newName == "." {
-				return nil, false, true, nil
-			}
-
-			// skip based on excludes
-			if ok, _ := pm.Matches(h.Name); ok {
-				return nil, false, true, nil
-			}
-
-			glog.V(5).Infof("Filtering archive %s -> %s", h.Name, newName)
-			h.Name = newName
-			// include all files
-			return nil, false, false, nil
-		})
+			r = in
+		}
+		err := FilterArchive(r, pw, fn)
 		pw.CloseWithError(err)
 	}()
-	return pr, pr, nil
+	return pr, nil
+}
+
+type archiveMapper struct {
+	exclude     *fileutils.PatternMatcher
+	rename      func(name string, isDir bool) (string, bool)
+	prefix      string
+	resetOwners bool
+}
+
+func newArchiveMapper(src, dst string, excludes []string, resetOwners bool) (*archiveMapper, string, error) {
+	ex, err := fileutils.NewPatternMatcher(excludes)
+	if err != nil {
+		return nil, "", err
+	}
+
+	isDestDir := strings.HasSuffix(dst, "/") || path.Base(dst) == "."
+	dst = path.Clean(dst)
+
+	var prefix string
+	archiveRoot := src
+	srcPattern := "*"
+	switch {
+	case src == "":
+		return nil, "", fmt.Errorf("source may not be empty")
+	case src == ".", src == "/":
+		// no transformation necessary
+	case strings.HasSuffix(src, "/"), strings.HasSuffix(src, "/."):
+		src = path.Clean(src)
+		archiveRoot = src
+		if archiveRoot != "/" && archiveRoot != "." {
+			prefix = path.Base(archiveRoot)
+		}
+	default:
+		src = path.Clean(src)
+		srcPattern = path.Base(src)
+		archiveRoot = path.Dir(src)
+		if archiveRoot != "/" && archiveRoot != "." {
+			prefix = path.Base(archiveRoot)
+		}
+	}
+
+	mapperFn := archivePathMapper(srcPattern, dst, isDestDir)
+
+	return &archiveMapper{
+		exclude:     ex,
+		rename:      mapperFn,
+		prefix:      prefix,
+		resetOwners: resetOwners,
+	}, archiveRoot, nil
+}
+
+func (m *archiveMapper) Filter(h *tar.Header, r io.Reader) ([]byte, bool, bool, error) {
+	if m.resetOwners {
+		h.Uid, h.Gid = 0, 0
+	}
+	// Trim a leading path, the prefix segment (which has no leading or trailing slashes), and
+	// the final leader segment. Depending on the segment, Docker could return /prefix/ or prefix/.
+	h.Name = strings.TrimPrefix(h.Name, "/")
+	if !strings.HasPrefix(h.Name, m.prefix) {
+		return nil, false, true, nil
+	}
+	h.Name = strings.TrimPrefix(strings.TrimPrefix(h.Name, m.prefix), "/")
+
+	// skip a file if it doesn't match the src
+	isDir := h.Typeflag == tar.TypeDir
+	newName, ok := m.rename(h.Name, isDir)
+	if !ok {
+		return nil, false, true, nil
+	}
+	if newName == "." {
+		return nil, false, true, nil
+	}
+	// skip based on excludes
+	if ok, _ := m.exclude.Matches(h.Name); ok {
+		return nil, false, true, nil
+	}
+	h.Name = newName
+	// include all files
+	return nil, false, false, nil
 }
 
 func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive.TarOptions {

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -730,7 +730,7 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 	for _, c := range copies {
 		// TODO: reuse source
 		for _, src := range c.Src {
-			glog.V(4).Infof("Archiving %s download=%t fromFS=%t", src, c.Download, c.FromFS)
+			glog.V(4).Infof("Archiving %s download=%t fromFS=%t from=%s", src, c.Download, c.FromFS, c.From)
 			var r io.Reader
 			var closer io.Closer
 			var err error
@@ -780,6 +780,7 @@ func (e *ClientExecutor) archiveFromContainer(from string, src, dst string) (io.
 		if other.Container == nil {
 			return nil, nil, fmt.Errorf("the stage %q has not been built yet", from)
 		}
+		glog.V(5).Infof("Using container %s as input for archive request", other.Container.ID)
 		containerID = other.Container.ID
 	} else {
 		glog.V(5).Infof("Creating a container temporarily for image input from %q in %s", from, src)
@@ -800,19 +801,20 @@ func (e *ClientExecutor) archiveFromContainer(from string, src, dst string) (io.
 	}
 
 	pr, pw := io.Pipe()
-	ar, arclose, err := archiveFromContainer(pr, src, dst, nil)
+	ar, archiveRoot, err := archiveFromContainer(pr, src, dst, nil)
 	if err != nil {
 		pr.Close()
 		return nil, nil, err
 	}
 	go func() {
+		glog.V(6).Infof("Download from container %s at path %s", containerID, archiveRoot)
 		err := e.Client.DownloadFromContainer(containerID, docker.DownloadFromContainerOptions{
 			OutputStream: pw,
-			Path:         src,
+			Path:         archiveRoot,
 		})
 		pw.CloseWithError(err)
 	}()
-	return ar, closers{pr.Close, arclose.Close}, nil
+	return ar, pr, nil
 }
 
 // TODO: this does not support decompressing nested archives for ADD (when the source is a compressed file)

--- a/dockerclient/testdata/Dockerfile.copyfrom_1
+++ b/dockerclient/testdata/Dockerfile.copyfrom_1
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN touch /a /b
+FROM busybox
+COPY --from=base /a /
+RUN ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_10
+++ b/dockerclient/testdata/Dockerfile.copyfrom_10
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+FROM busybox
+COPY --from=base /a/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/dockerclient/testdata/Dockerfile.copyfrom_2
+++ b/dockerclient/testdata/Dockerfile.copyfrom_2
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN touch /a
+FROM busybox
+COPY --from=base /a /a
+RUN ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_3
+++ b/dockerclient/testdata/Dockerfile.copyfrom_3
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN touch /a
+FROM busybox
+WORKDIR /b
+COPY --from=base /a .
+RUN ls -al /b/a

--- a/dockerclient/testdata/Dockerfile.copyfrom_4
+++ b/dockerclient/testdata/Dockerfile.copyfrom_4
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+FROM busybox
+COPY --from=base /a/b/ /b/
+RUN ls -al /b/1 /b/2 /b && ! ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_5
+++ b/dockerclient/testdata/Dockerfile.copyfrom_5
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+FROM busybox
+COPY --from=base /a/b/* /b/
+RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/dockerclient/testdata/Dockerfile.copyfrom_6
+++ b/dockerclient/testdata/Dockerfile.copyfrom_6
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+FROM busybox
+COPY --from=base /a/b/. /b/
+RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/dockerclient/testdata/Dockerfile.copyfrom_7
+++ b/dockerclient/testdata/Dockerfile.copyfrom_7
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN touch /b
+FROM busybox
+COPY --from=base /b /a
+RUN ls -al /a && ! ls -al /b

--- a/dockerclient/testdata/Dockerfile.copyfrom_8
+++ b/dockerclient/testdata/Dockerfile.copyfrom_8
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/b
+FROM busybox
+COPY --from=base /a/b /a
+RUN ls -al /a && ! ls -al /b

--- a/dockerclient/testdata/Dockerfile.copyfrom_9
+++ b/dockerclient/testdata/Dockerfile.copyfrom_9
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+FROM busybox
+COPY --from=base /a/1 /a/b/c/
+RUN ls -al /a/b/c/1 && ! ls -al /a/b/1

--- a/dockerclient/testdata/copyfrom/Dockerfile
+++ b/dockerclient/testdata/copyfrom/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:7 as base
+RUN mkdir -p /a/blah && touch /a/blah/1 /a/blah/2
+FROM centos:7
+COPY --from=base /a/blah/* /blah/


### PR DESCRIPTION
Some cases where a wildcard was specified would fail.  Refactored the core code to share code paths and more carefully processed directory paths.  New manual test cases created (future change will turn these into a conformance suite).