### PR TITLE
Transient mount was broken for absolute paths

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -455,10 +455,9 @@ func (e *ClientExecutor) PopulateTransientMounts(opts docker.CreateContainerOpti
 
 	var copies []imagebuilder.Copy
 	for i, mount := range transientMounts {
-		source := mount.SourcePath
 		copies = append(copies, imagebuilder.Copy{
 			FromFS: true,
-			Src:    []string{filepath.Join(e.Directory, source)},
+			Src:    []string{mount.SourcePath},
 			Dest:   filepath.Join(e.ContainerTransientMount, strconv.Itoa(i)),
 		})
 	}

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -60,7 +60,6 @@ func TestMount(t *testing.T) {
 
 	out := &bytes.Buffer{}
 	e.Out, e.ErrOut = out, out
-	e.Directory = "."
 	e.Tag = filepath.Base(tmpDir)
 	e.TransientMounts = []Mount{
 		{SourcePath: "testdata/volume/", DestinationPath: "/tmp/test"},


### PR DESCRIPTION
This was an accidental change due to another unrelated test problem in https://github.com/openshift/imagebuilder/pull/80/commits/27430d5294f7e912e0321db4b9ab9ee798b75dc7. Transient mount path should not have been changed.