### PR TITLE
Check if COPY/ADD destination is a directory

### DIFF
--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -82,7 +82,7 @@ func main() {
 		if glog.V(2) {
 			log.Printf("Builder: "+format, args...)
 		} else {
-			fmt.Fprintf(options.ErrOut, "--> %s\n", fmt.Sprintf(format, args...))
+			fmt.Fprintf(options.Out, "--> %s\n", fmt.Sprintf(format, args...))
 		}
 	}
 

--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -38,7 +38,9 @@ func FilterArchive(r io.Reader, w io.Writer, fn TransformFileFunc) error {
 		}
 
 		var body io.Reader = tr
+		name := h.Name
 		data, ok, skip, err := fn(h, tr)
+		glog.V(6).Infof("Transform %s -> %s: data=%t ok=%t skip=%t err=%v", name, h.Name, data != nil, ok, skip, err)
 		if err != nil {
 			return err
 		}
@@ -100,7 +102,7 @@ func NewLazyArchive(fn CreateFileFunc) io.ReadCloser {
 	return pr
 }
 
-func archiveFromURL(src, dst, tempDir string) (io.Reader, io.Closer, error) {
+func archiveFromURL(src, dst, tempDir string, check DirectoryCheck) (io.Reader, io.Closer, error) {
 	// get filename from URL
 	u, err := url.Parse(src)
 	if err != nil {
@@ -151,7 +153,7 @@ func archiveFromURL(src, dst, tempDir string) (io.Reader, io.Closer, error) {
 	return archive, closers{resp.Body.Close, archive.Close}, nil
 }
 
-func archiveFromDisk(directory string, src, dst string, allowDownload bool, excludes []string) (io.Reader, io.Closer, error) {
+func archiveFromDisk(directory string, src, dst string, allowDownload bool, excludes []string, check DirectoryCheck) (io.Reader, io.Closer, error) {
 	var err error
 	if filepath.IsAbs(src) {
 		src, err = filepath.Rel(filepath.Dir(src), src)
@@ -173,11 +175,64 @@ func archiveFromDisk(directory string, src, dst string, allowDownload bool, excl
 		directory = filepath.Dir(directory)
 	}
 
-	options := archiveOptionsFor(infos, dst, excludes)
+	options, err := archiveOptionsFor(infos, dst, excludes, check)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	glog.V(4).Infof("Tar of %s %#v", directory, options)
 	rc, err := archive.TarWithOptions(directory, options)
 	return rc, rc, err
+}
+
+func archiveFromFile(file string, src, dst string, excludes []string, check DirectoryCheck) (io.Reader, io.Closer, error) {
+	var err error
+	if filepath.IsAbs(src) {
+		src, err = filepath.Rel(filepath.Dir(src), src)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	mapper, _, err := newArchiveMapper(src, dst, excludes, true, check)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r, err := transformArchive(f, true, mapper.Filter)
+	return r, f, err
+}
+
+func archiveFromContainer(in io.Reader, src, dst string, excludes []string, check DirectoryCheck) (io.Reader, string, error) {
+	mapper, archiveRoot, err := newArchiveMapper(src, dst, excludes, false, check)
+	if err != nil {
+		return nil, "", err
+	}
+
+	r, err := transformArchive(in, false, mapper.Filter)
+	return r, archiveRoot, err
+}
+
+func transformArchive(r io.Reader, compressed bool, fn TransformFileFunc) (io.Reader, error) {
+	pr, pw := io.Pipe()
+	go func() {
+		if compressed {
+			in, err := archive.DecompressStream(r)
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			r = in
+		}
+		err := FilterArchive(r, pw, fn)
+		pw.CloseWithError(err)
+	}()
+	return pr, nil
 }
 
 // * -> test
@@ -232,7 +287,7 @@ func archivePathMapper(src, dst string, isDestDir bool) (fn func(name string, is
 	}
 	prefix += string(filepath.Separator)
 
-	// nested with pattern pattern
+	// nested with pattern
 	return func(name string, isDir bool) (string, bool) {
 		remainder := strings.TrimPrefix(name, prefix)
 		if remainder == name {
@@ -251,56 +306,6 @@ func archivePathMapper(src, dst string, isDestDir bool) (fn func(name string, is
 	}
 }
 
-func archiveFromFile(file string, src, dst string, excludes []string) (io.Reader, io.Closer, error) {
-	var err error
-	if filepath.IsAbs(src) {
-		src, err = filepath.Rel(filepath.Dir(src), src)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	mapper, _, err := newArchiveMapper(src, dst, excludes, true)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	f, err := os.Open(file)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	r, err := transformArchive(f, true, mapper.Filter)
-	return r, f, err
-}
-
-func archiveFromContainer(in io.Reader, src, dst string, excludes []string) (io.Reader, string, error) {
-	mapper, archiveRoot, err := newArchiveMapper(src, dst, excludes, false)
-	if err != nil {
-		return nil, "", err
-	}
-
-	r, err := transformArchive(in, false, mapper.Filter)
-	return r, archiveRoot, err
-}
-
-func transformArchive(r io.Reader, compressed bool, fn TransformFileFunc) (io.Reader, error) {
-	pr, pw := io.Pipe()
-	go func() {
-		if compressed {
-			in, err := archive.DecompressStream(r)
-			if err != nil {
-				pw.CloseWithError(err)
-				return
-			}
-			r = in
-		}
-		err := FilterArchive(r, pw, fn)
-		pw.CloseWithError(err)
-	}()
-	return pr, nil
-}
-
 type archiveMapper struct {
 	exclude     *fileutils.PatternMatcher
 	rename      func(name string, isDir bool) (string, bool)
@@ -308,7 +313,7 @@ type archiveMapper struct {
 	resetOwners bool
 }
 
-func newArchiveMapper(src, dst string, excludes []string, resetOwners bool) (*archiveMapper, string, error) {
+func newArchiveMapper(src, dst string, excludes []string, resetOwners bool, check DirectoryCheck) (*archiveMapper, string, error) {
 	ex, err := fileutils.NewPatternMatcher(excludes)
 	if err != nil {
 		return nil, "", err
@@ -316,6 +321,13 @@ func newArchiveMapper(src, dst string, excludes []string, resetOwners bool) (*ar
 
 	isDestDir := strings.HasSuffix(dst, "/") || path.Base(dst) == "."
 	dst = path.Clean(dst)
+	if !isDestDir && check != nil {
+		isDir, err := check.IsDirectory(dst)
+		if err != nil {
+			return nil, "", err
+		}
+		isDestDir = isDir
+	}
 
 	var prefix string
 	archiveRoot := src
@@ -380,11 +392,19 @@ func (m *archiveMapper) Filter(h *tar.Header, r io.Reader) ([]byte, bool, bool, 
 	return nil, false, false, nil
 }
 
-func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive.TarOptions {
+func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string, check DirectoryCheck) (*archive.TarOptions, error) {
 	dst = trimLeadingPath(dst)
 	dstIsDir := strings.HasSuffix(dst, "/") || dst == "." || dst == "/" || strings.HasSuffix(dst, "/.")
 	dst = trimTrailingSlash(dst)
 	dstIsRoot := dst == "." || dst == "/"
+
+	if !dstIsDir && check != nil {
+		isDir, err := check.IsDirectory(dst)
+		if err != nil {
+			return nil, fmt.Errorf("unable to check whether %s is a directory: %v", dst, err)
+		}
+		dstIsDir = isDir
+	}
 
 	options := &archive.TarOptions{
 		ChownOpts: &idtools.IDPair{UID: 0, GID: 0},
@@ -392,7 +412,7 @@ func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive
 
 	pm, err := fileutils.NewPatternMatcher(excludes)
 	if err != nil {
-		return options
+		return options, nil
 	}
 
 	for _, info := range infos {
@@ -437,7 +457,7 @@ func archiveOptionsFor(infos []CopyInfo, dst string, excludes []string) *archive
 	}
 
 	options.ExcludePatterns = excludes
-	return options
+	return options, nil
 }
 
 func sourceToDestinationName(src, dst string, forceDir bool) string {

--- a/dockerclient/archive_test.go
+++ b/dockerclient/archive_test.go
@@ -13,6 +13,20 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
+type testDirectoryCheck map[string]bool
+
+func (c testDirectoryCheck) IsDirectory(path string) (bool, error) {
+	if c == nil {
+		return false, nil
+	}
+
+	isDir, ok := c[path]
+	if !ok {
+		return false, fmt.Errorf("no path defined for %s", path)
+	}
+	return isDir, nil
+}
+
 type archiveGenerator struct {
 	Headers []*tar.Header
 }
@@ -81,6 +95,7 @@ func Test_archiveFromFile(t *testing.T) {
 		dst      string
 		excludes []string
 		expect   []string
+		check    map[string]bool
 	}{
 		{
 			file: testArchive,
@@ -233,6 +248,7 @@ func Test_archiveFromFile(t *testing.T) {
 				testCase.src,
 				testCase.dst,
 				testCase.excludes,
+				testDirectoryCheck(testCase.check),
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -266,6 +282,7 @@ func Test_archiveFromContainer(t *testing.T) {
 		excludes []string
 		expect   []string
 		path     string
+		check    map[string]bool
 	}{
 		{
 			gen:  newArchiveGenerator().File("file").Dir("test").File("test/file2"),
@@ -395,6 +412,14 @@ func Test_archiveFromContainer(t *testing.T) {
 			expect: nil,
 		},
 		{
+			gen:    newArchiveGenerator().File("b"),
+			src:    "/a/b",
+			dst:    "/a",
+			check:  map[string]bool{"/a": true},
+			path:   "/a",
+			expect: nil,
+		},
+		{
 			gen:  newArchiveGenerator().Dir("a/").File("a/b"),
 			src:  "/a/b",
 			dst:  "/a",
@@ -412,6 +437,7 @@ func Test_archiveFromContainer(t *testing.T) {
 				testCase.src,
 				testCase.dst,
 				testCase.excludes,
+				testDirectoryCheck(testCase.check),
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -251,6 +251,14 @@ func TestConformanceInternal(t *testing.T) {
 			ContextDir: "testdata/dir",
 		},
 		{
+			Name:       "copy to dir",
+			ContextDir: "testdata/copy",
+		},
+		{
+			Name:       "copy to renamed file",
+			ContextDir: "testdata/copyrename",
+		},
+		{
 			Name:       "directory with slash",
 			ContextDir: "testdata/overlapdir",
 			Dockerfile: "Dockerfile.with_slash",

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -391,8 +391,8 @@ func TestTransientMount(t *testing.T) {
 	e.AllowPull = true
 	e.Directory = "testdata"
 	e.TransientMounts = []Mount{
-		{SourcePath: "dir", DestinationPath: "/mountdir"},
-		{SourcePath: "Dockerfile.env", DestinationPath: "/mountfile"},
+		{SourcePath: "testdata/dir", DestinationPath: "/mountdir"},
+		{SourcePath: "testdata/Dockerfile.env", DestinationPath: "/mountfile"},
 	}
 	e.Tag = fmt.Sprintf("conformance%d", rand.Int63())
 

--- a/dockerclient/copyinfo_test.go
+++ b/dockerclient/copyinfo_test.go
@@ -17,6 +17,7 @@ func TestCalcCopyInfo(t *testing.T) {
 		paths          map[string]struct{}
 		excludes       []string
 		rebaseNames    map[string]string
+		check          map[string]bool
 	}{
 		{
 			origPath:       "subdir/*",
@@ -96,6 +97,33 @@ func TestCalcCopyInfo(t *testing.T) {
 		{
 			origPath:       ".",
 			dstPath:        "copy",
+			rootPath:       "testdata/singlefile",
+			allowWildcards: true,
+			errFn:          nilErr,
+			paths: map[string]struct{}{
+				"Dockerfile": {},
+			},
+			rebaseNames: map[string]string{
+				"Dockerfile": "copy/Dockerfile",
+			},
+		},
+		{
+			origPath:       "Dockerfile",
+			dstPath:        "copy",
+			rootPath:       "testdata/singlefile",
+			allowWildcards: true,
+			errFn:          nilErr,
+			paths: map[string]struct{}{
+				"Dockerfile": {},
+			},
+			rebaseNames: map[string]string{
+				"Dockerfile": "copy",
+			},
+		},
+		{
+			origPath:       "Dockerfile",
+			dstPath:        "copy",
+			check:          map[string]bool{"copy": true},
 			rootPath:       "testdata/singlefile",
 			allowWildcards: true,
 			errFn:          nilErr,
@@ -211,7 +239,10 @@ func TestCalcCopyInfo(t *testing.T) {
 				t.Errorf("did not see paths: %#v", expect)
 			}
 
-			options := archiveOptionsFor(infos, test.dstPath, test.excludes)
+			options, err := archiveOptionsFor(infos, test.dstPath, test.excludes, testDirectoryCheck(test.check))
+			if err != nil {
+				t.Fatal(err)
+			}
 			if !reflect.DeepEqual(test.rebaseNames, options.RebaseNames) {
 				t.Errorf("rebase names did not match:\n%#v\n%#v", test.rebaseNames, options.RebaseNames)
 			}

--- a/dockerclient/directory.go
+++ b/dockerclient/directory.go
@@ -1,0 +1,87 @@
+package dockerclient
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+type DirectoryCheck interface {
+	IsDirectory(path string) (bool, error)
+}
+
+type directoryCheck struct {
+	containerID string
+	client      *docker.Client
+}
+
+func newDirectoryCheck(client *docker.Client, containerID string) *directoryCheck {
+	return &directoryCheck{
+		containerID: containerID,
+		client:      client,
+	}
+}
+
+func (c *directoryCheck) IsDirectory(path string) (bool, error) {
+	if path == "/" || path == "." || path == "./" {
+		return true, nil
+	}
+
+	dir, err := isContainerPathDirectory(c.client, c.containerID, path)
+	if err != nil {
+		return false, err
+	}
+
+	return dir, nil
+}
+
+func isContainerPathDirectory(client *docker.Client, containerID, path string) (bool, error) {
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	ctx, cancel := context.WithCancel(context.TODO())
+	go func() {
+		err := client.DownloadFromContainer(containerID, docker.DownloadFromContainerOptions{
+			OutputStream: pw,
+			Path:         path,
+			Context:      ctx,
+		})
+		if err != nil {
+			if apiErr, ok := err.(*docker.Error); ok && apiErr.Status == 404 {
+				glog.V(4).Infof("path %s did not exist in container %s: %v", path, containerID, err)
+				err = nil
+			}
+			if err != nil && err != context.Canceled {
+				glog.V(6).Infof("error while checking directory contents for container %s at path %s: %v", containerID, path, err)
+			}
+		}
+		pw.CloseWithError(err)
+	}()
+
+	tr := tar.NewReader(pr)
+
+	h, err := tr.Next()
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+		return false, err
+	}
+
+	glog.V(4).Infof("Retrieved first header from container %s at path %s: %#v", containerID, path, h)
+
+	// take the remainder of the input and discard it
+	go func() {
+		cancel()
+		n, err := io.Copy(ioutil.Discard, pr)
+		if n > 0 || err != nil {
+			glog.V(6).Infof("Discarded %d bytes from end of container directory check, and got error: %v", n, err)
+		}
+	}()
+
+	return h.FileInfo().IsDir(), nil
+}

--- a/dockerclient/testdata/copy/Dockerfile
+++ b/dockerclient/testdata/copy/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+COPY script /usr/bin
+RUN ls -al /usr/bin/script

--- a/dockerclient/testdata/copy/script
+++ b/dockerclient/testdata/copy/script
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 0

--- a/dockerclient/testdata/copyrename/Dockerfile
+++ b/dockerclient/testdata/copyrename/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+COPY file1 /usr/bin/file2
+RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1

--- a/dockerclient/testdata/copyrename/file1
+++ b/dockerclient/testdata/copyrename/file1
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 0


### PR DESCRIPTION
When a user specifies `COPY a /usr/bin` where a is a file, even though the
Dockerfile docs say that this should be a rename, the Docker 1.12/1.13
daemons first check whether the target is a directory before deciding
whether to rename it.

We perform that check by downloading the destination from the container and
checking whether the first entry is a file or a directory. If the first
entry is not found, the location is assumed not to exist and the target is
considered to be a file destination. We terminate early to avoid downloading
other files.

Fixes #83, #84