### PR TITLE
`COPY a /a` was incorrect

### DIFF
--- a/dockerclient/archive_test.go
+++ b/dockerclient/archive_test.go
@@ -428,6 +428,13 @@ func Test_archiveFromContainer(t *testing.T) {
 				"/a",
 			},
 		},
+		{
+			gen:    newArchiveGenerator().Dir("./a").File("./a/b"),
+			src:    "a",
+			dst:    "/a",
+			path:   ".",
+			expect: []string{"/a/b"},
+		},
 	}
 	for i := range testCases {
 		testCase := testCases[i]

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -111,6 +111,8 @@ func TestCopyFrom(t *testing.T) {
 		{name: "copy file to deeper directory with explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c/", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
 		{name: "copy file to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
 		{name: "copy directory to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a /a/b/c", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
+		{name: "copy directory to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
+		{name: "copy directory trailing to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a/. /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
 	}
 	for i, testCase := range testCases {
 		name := fmt.Sprintf("%d", i)
@@ -143,6 +145,7 @@ func TestCopyFrom(t *testing.T) {
 
 			stages := imagebuilder.NewStages(node, b)
 			if _, err := e.Stages(b, stages, ""); err != nil {
+				t.Log(out.String())
 				t.Fatal(err)
 			}
 		})
@@ -253,6 +256,10 @@ func TestConformanceInternal(t *testing.T) {
 		{
 			Name:       "copy to dir",
 			ContextDir: "testdata/copy",
+		},
+		{
+			Name:       "copy dir",
+			ContextDir: "testdata/copydir",
 		},
 		{
 			Name:       "copy to renamed file",

--- a/dockerclient/copyinfo_test.go
+++ b/dockerclient/copyinfo_test.go
@@ -213,6 +213,20 @@ func TestCalcCopyInfo(t *testing.T) {
 				"subdir": "test",
 			},
 		},
+		{
+			origPath:       "dir",
+			dstPath:        "/dir",
+			check:          map[string]bool{"dir": false},
+			rootPath:       "testdata/copydir",
+			allowWildcards: true,
+			errFn:          nilErr,
+			paths: map[string]struct{}{
+				"dir": {},
+			},
+			rebaseNames: map[string]string{
+				"dir": "dir",
+			},
+		},
 	}
 
 	for i, test := range tests {

--- a/dockerclient/testdata/copydir/Dockerfile
+++ b/dockerclient/testdata/copydir/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+COPY dir /dir
+RUN ls -al /dir/file


### PR DESCRIPTION
Copy from an explicit directory to either an implicit or explicit
destination directory should always be a contents copy

@stevekuznetsov this should fix your issue