### PR TITLE
Ensure job control is on in interactive shells

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -685,6 +685,7 @@ func (e *ClientExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 	exec, err := e.Client.CreateExec(docker.CreateExecOptions{
 		Cmd:          config.Cmd,
 		Container:    e.Container.ID,
+		Tty:          true,
 		AttachStdout: true,
 		AttachStderr: true,
 		User:         config.User,

--- a/dockerclient/testdata/runchild/Dockerfile
+++ b/dockerclient/testdata/runchild/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+ADD child.sh .
+RUN /child.sh
+RUN ps -ef

--- a/dockerclient/testdata/runchild/child.sh
+++ b/dockerclient/testdata/runchild/child.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "starting child"
+( sleep 10; echo "child done" ) &
+echo "script done"


### PR DESCRIPTION
Without TTY on exec, shell processes behave inconsistently with docker
build. A script that forks will wait to exit in imagebuilder but not
docker build unless we also set our input to a TTY.

Fixes #88