### PR TITLE
Add copy chown handling to dispatchers

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -27,6 +27,9 @@ type Copy struct {
 	Src      []string
 	Dest     string
 	Download bool
+	// If set, the owner:group for the destination.  This value is passed
+	// to the executor for handling.
+	Chown string
 }
 
 // Run defines a run operation required in the container.
@@ -51,7 +54,7 @@ func (logExecutor) Preserve(path string) error {
 
 func (logExecutor) Copy(excludes []string, copies ...Copy) error {
 	for _, c := range copies {
-		log.Printf("COPY %v -> %s (from:%s download:%t)", c.Src, c.Dest, c.From, c.Download)
+		log.Printf("COPY %v -> %s (from:%s download:%t), chown: %s", c.Src, c.Dest, c.From, c.Download, c.Chown)
 	}
 	return nil
 }

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -149,18 +149,21 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 	}
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
+	var chown string
 	var from string
 	if len(flagArgs) > 0 {
 		for _, arg := range flagArgs {
 			switch {
+			case strings.HasPrefix(arg, "--chown="):
+				chown = strings.TrimPrefix(arg, "--chown=")
 			case strings.HasPrefix(arg, "--from="):
 				from = strings.TrimPrefix(arg, "--from=")
 			default:
-				return fmt.Errorf("COPY only supports the --from=<image|stage> flag")
+				return fmt.Errorf("COPY only supports the --chown=<uid:gid> and the --from=<image|stage> flags")
 			}
 		}
 	}
-	b.PendingCopies = append(b.PendingCopies, Copy{From: from, Src: args[0:last], Dest: dest, Download: false})
+	b.PendingCopies = append(b.PendingCopies, Copy{From: from, Src: args[0:last], Dest: dest, Download: false, Chown: chown})
 	return nil
 }
 

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -27,9 +27,67 @@ func TestDispatchCopy(t *testing.T) {
 			Src:      []string{"/go/src/github.com/kubernetes-incubator/service-catalog/controller-manager"},
 			Dest:     "/root/", // destination must contain a trailing slash
 			Download: false,
+			Chown:    "",
 		},
 	}
 	if !reflect.DeepEqual(mybuilder.PendingCopies, expectedPendingCopies) {
 		t.Errorf("Expected %v, got %v\n", expectedPendingCopies, mybuilder.PendingCopies)
+	}
+}
+
+func TestDispatchCopyChown(t *testing.T) {
+	mybuilder := Builder{
+		RunConfig: docker.Config{
+			WorkingDir: "/root",
+			Cmd:        []string{"/bin/sh"},
+			Image:      "busybox",
+		},
+	}
+
+	mybuilder2 := Builder{
+		RunConfig: docker.Config{
+			WorkingDir: "/root",
+			Cmd:        []string{"/bin/sh"},
+			Image:      "alpine",
+		},
+	}
+
+	// Test Bad chown values
+	args := []string{"/go/src/github.com/kubernetes-incubator/service-catalog/controller-manager", "."}
+	flagArgs := []string{"--chown=1376:1376"}
+	original := "COPY --chown=1376:1376 /go/src/github.com/kubernetes-incubator/service-catalog/controller-manager ."
+	if err := dispatchCopy(&mybuilder, args, nil, flagArgs, original); err != nil {
+		t.Errorf("dispatchCopy error: %v", err)
+	}
+	expectedPendingCopies := []Copy{
+		{
+			From:     "",
+			Src:      []string{"/go/src/github.com/kubernetes-incubator/service-catalog/controller-manager"},
+			Dest:     "/root/", // destination must contain a trailing slash
+			Download: false,
+			Chown:    "6731:6731",
+		},
+	}
+	if reflect.DeepEqual(mybuilder.PendingCopies, expectedPendingCopies) {
+		t.Errorf("Expected %v, to not match %v\n", expectedPendingCopies, mybuilder.PendingCopies)
+	}
+
+	// Test Good chown values
+	flagArgs = []string{"--chown=6731:6731"}
+	original = "COPY --chown=6731:6731 /go/src/github.com/kubernetes-incubator/service-catalog/controller-manager ."
+	if err := dispatchCopy(&mybuilder2, args, nil, flagArgs, original); err != nil {
+		t.Errorf("dispatchCopy error: %v", err)
+	}
+	expectedPendingCopies = []Copy{
+		{
+			From:     "",
+			Src:      []string{"/go/src/github.com/kubernetes-incubator/service-catalog/controller-manager"},
+			Dest:     "/root/", // destination must contain a trailing slash
+			Download: false,
+			Chown:    "6731:6731",
+		},
+	}
+	if !reflect.DeepEqual(mybuilder2.PendingCopies, expectedPendingCopies) {
+		t.Errorf("Expected %v, to match %v\n", expectedPendingCopies, mybuilder2.PendingCopies)
 	}
 }


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Allows a Dockerfile copy command like:

```
COPY --chown=3267:3267 tom.txt /tmp
```
Passing the value to the executor to handle.  This addresses #77.