### PR TITLE
Add field for handling AS clause in FROM

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -224,6 +224,8 @@ type Builder struct {
 	PendingCopies  []Copy
 
 	Warnings []string
+
+	AsImageName string
 }
 
 func NewBuilder(args map[string]string) *Builder {

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -187,6 +187,9 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 			return fmt.Errorf("Windows does not support FROM scratch")
 		}
 	}
+	if len(args) == 3 {
+		b.AsImageName = args[2]
+	}
 	b.RunConfig.Image = name
 	// TODO: handle onbuild
 	return nil


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When processing a Dockerfile line like:

FROM centos AS base

Imagebuilder was catching this, but was not storing the "AS" portion away so the caller could reference it.  We're now noting the value in the Builder struct so Buildah an others can reference it.

I wasn't quite sure how to test this here, if tests are desired, I'll have to noodle a bit more.