### PR TITLE
WIP - Revert getError removal from PR 45

### DIFF
--- a/imageprogress/progress_test.go
+++ b/imageprogress/progress_test.go
@@ -14,6 +14,7 @@ func TestReports(t *testing.T) {
 	tests := []struct {
 		name     string
 		gen      func(*progressGenerator)
+		errExpected bool
 		expected report
 	}{
 		{
@@ -54,17 +55,12 @@ func TestReports(t *testing.T) {
 			},
 		},
 		{
-			name: "ignore error",
+			name: "detect error",
 			gen: func(p *progressGenerator) {
-				p.status("1", "Downloading")
-				p.status("2", "Pull complete")
 				p.status("1", "Downloading")
 				p.err("an error")
 			},
-			expected: report{
-				statusDownloading: &layerDetail{Count: 1},
-				statusComplete:    &layerDetail{Count: 1},
-			},
+			errExpected: true,
 		},
 	}
 
@@ -91,7 +87,12 @@ func TestReports(t *testing.T) {
 			w.(*imageProgressWriter).stableThreshhold = 0
 			_, err := io.Copy(w, pipeIn)
 			if err != nil {
-				t.Fatalf("%s: unexpected: %v", test.name, err)
+				if !test.errExpected {
+					t.Errorf("%s: unexpected: %v", test.name, err)
+				}
+			}
+			if test.errExpected {
+				t.Errorf("%s: did not get expected error", test.name)
 			}
 			// TODO: remove the goroutine inside of the progress generator or make it sync on close
 			time.Sleep(10 * time.Millisecond)
@@ -100,6 +101,31 @@ func TestReports(t *testing.T) {
 				t.Errorf("%s: unexpected report, got: %v, expected: %v", test.name, lastReport, test.expected)
 			}
 		})
+	}
+}
+
+func TestErrorOnCopy(t *testing.T) {
+	// Producer pipe
+	genIn, genOut := io.Pipe()
+	p := newProgressGenerator(genOut)
+	// generate some data
+	go func() {
+		for i := 0; i < 100; i++ {
+			p.status("1", "Downloading")
+			p.status("2", "Downloading")
+			p.status("3", "Downloading")
+		}
+		p.err("data error")
+		genOut.Close()
+	}()
+	w := newWriter(func(r report) {}, func(a, b report) bool { return true })
+	// Ensure that the error is propagated to the copy
+	_, err := io.Copy(w, genIn)
+	if err == nil {
+		t.Errorf("Did not get an error when copying to writer")
+	}
+	if err.Error() != "data error" {
+		t.Errorf("Did not get expected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>
I'm adding back the error handling that was removed vrom #45 in order to hopefully address https://bugzilla.redhat.com/show_bug.cgi?id=1626228.

However the progress_test.go tests that should error out on error don't seem to be:

```
# go test
--- FAIL: TestReports (0.04s)
    --- FAIL: TestReports/detect_error (0.01s)
    	progress_test.go:95: detect error: did not get expected error
--- FAIL: TestErrorOnCopy (0.00s)
	progress_test.go:125: Did not get an error when copying to writer
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x513e20]

goroutine 19 [running]:
testing.tRunner.func1(0xc4200805a0)
	/usr/lib/golang/src/testing/testing.go:711 +0x2d2
panic(0x53cc60, 0x61fba0)
	/usr/lib/golang/src/runtime/panic.go:491 +0x283
github.com/openshift/imagebuilder/imageprogress.TestErrorOnCopy(0xc4200805a0)
	/root/tsweeney/workspaces/imagebuilder/src/github.com/openshift/imagebuilder/imageprogress/progress_test.go:127 +0x280
testing.tRunner(0xc4200805a0, 0x56f1c0)
	/usr/lib/golang/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
	/usr/lib/golang/src/testing/testing.go:789 +0x2de
exit status 2
FAIL	github.com/openshift/imagebuilder/imageprogress	0.053s
```

I'm not sure if they're failing as I've not set up the error condition in the test properly or if the change from #45 of io.Writer to io.Writer.Closer is causing the error not to be generated/caught.  As I've not looked at this code prior to this afternoon, any thoughts/suggestions welcomed.