### PR TITLE
Detect and report errors in imageprogress.imageProgressWriter

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -592,10 +592,11 @@ func (e *ClientExecutor) LoadImage(from string) (*docker.Image, error) {
 			pullImageOptions.RawJSONStream = false
 		}
 		authConfig := docker.AuthConfiguration{Username: config.Username, ServerAddress: config.ServerAddress, Password: config.Password}
-		if err = e.Client.PullImage(pullImageOptions, authConfig); err == nil {
+		pullErr := e.Client.PullImage(pullImageOptions, authConfig)
+		if pullErr == nil {
 			break
 		}
-		lastErr = err
+		lastErr = pullErr
 		continue
 	}
 	if lastErr != nil {

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -581,7 +581,12 @@ func (e *ClientExecutor) LoadImage(from string) (*docker.Image, error) {
 		var pullErr error
 		func() { // A scope for defer
 			pullWriter := imageprogress.NewPullWriter(outputProgress)
-			defer pullWriter.Close()
+			defer func() {
+				err := pullWriter.Close()
+				if pullErr == nil {
+					pullErr = err
+				}
+			}()
 
 			pullImageOptions := docker.PullImageOptions{
 				Repository:    repository,


### PR DESCRIPTION
#45, while otherwise making the goroutine termination more robust, dropped error handling and detection, which could not really work reliably (in most cases, the error would be reported by `PipeReader.CloseWithError`, but the writers callers would not write to the pipe again and never detect the error.)

This restores the error detection code, and implements a reliable error reporting mechanism: The reading goroutine reports its final status through a `chan error`, and `imageProgressWriter.Close` now **BLOCKS** on the goroutine finishing and reads the error status. (The blocking should, hopefully, not be a problem, because the callbacks tend to ultimately only log the progress or throw it away. Nevertheless, it is notable.)

Callers still need to be updated to collect and act upon the error from `imageProgressWriter.Close`. So, `ClientExecutor.LoadImage` is updated that way as well.

The `imageprogress` parts are reasonably well covered with unit tests, notably the `TestErrorOnCopy` test fairly closely mirrors how progress is provided by `fsouza/go-dockerclient`. The `ClientExecutor.LoadImage` part is **absolutely untested** by me.

See the individual commit messages for details.