### PR TITLE
Copy .dockerignore into image for compatibility with Docker

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -129,12 +129,9 @@ func NewClientExecutor(client *docker.Client) *ClientExecutor {
 }
 
 func (e *ClientExecutor) DefaultExcludes() error {
-	excludes, err := imagebuilder.ParseDockerignore(e.Directory)
-	if err != nil {
-		return err
-	}
-	e.Excludes = append(excludes, ".dockerignore")
-	return nil
+	var err error
+	e.Excludes, err = imagebuilder.ParseDockerignore(e.Directory)
+	return err
 }
 
 // WithName creates a new child executor that will be used whenever a COPY statement


### PR DESCRIPTION
From what I can tell, this is inconsistent with how `docker build`. I went through `git blame`, but it ended at the first commit where this is extracted out from Openshift by clayton, so I didn't dig deeper to see if there's a good reason for excluding this file.

Fixes #100 