### PR TITLE
Allow relative paths in `COPY --from=STAGE` by checking working dir

### DIFF
--- a/dockerclient/testdata/multistage/Dockerfile.relative-copy_1
+++ b/dockerclient/testdata/multistage/Dockerfile.relative-copy_1
@@ -1,0 +1,7 @@
+FROM busybox AS builder
+WORKDIR /usr
+RUN echo "test" > /usr/a.txt
+
+FROM busybox
+COPY --from=builder ./a.txt /other/
+RUN ls /other/a.txt

--- a/dockerclient/testdata/multistage/Dockerfile.relative-copy_2
+++ b/dockerclient/testdata/multistage/Dockerfile.relative-copy_2
@@ -1,0 +1,7 @@
+FROM busybox AS builder
+WORKDIR /usr
+RUN echo "test" > /usr/a.txt
+
+FROM busybox
+COPY --from=builder ./a.txt /b.txt
+RUN ls /b.txt


### PR DESCRIPTION
Use the previous stage's working dir to do relative paths.