### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ is ignored.
 
 ## Code Example
 
-```
+```go
 f, err := os.Open("path/to/Dockerfile")
 if err != nil {
 	return err


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.