### PR TITLE
Add ThroughTarget function to builder

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -163,6 +163,7 @@ func (stages Stages) ByName(name string) (Stage, bool) {
 	return Stage{}, false
 }
 
+// Get just the target stage.
 func (stages Stages) ByTarget(target string) (Stages, bool) {
 	if len(target) == 0 {
 		return stages, true
@@ -170,6 +171,19 @@ func (stages Stages) ByTarget(target string) (Stages, bool) {
 	for i, stage := range stages {
 		if stage.Name == target {
 			return stages[i : i+1], true
+		}
+	}
+	return nil, false
+}
+
+// Get all the stages up to and including the target.
+func (stages Stages) ThroughTarget(target string) (Stages, bool) {
+	if len(target) == 0 {
+		return stages, true
+	}
+	for i, stage := range stages {
+		if stage.Name == target {
+			return stages[0 : i+1], true
 		}
 	}
 	return nil, false

--- a/builder_test.go
+++ b/builder_test.go
@@ -66,6 +66,72 @@ func TestVolumeSet(t *testing.T) {
 	}
 }
 
+func TestByTarget(t *testing.T) {
+	n, err := ParseFile("dockerclient/testdata/Dockerfile.target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stages, err := NewStages(n, NewBuilder(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 3 {
+		t.Fatalf("expected 3 stages, got %d", len(stages))
+	}
+	t.Logf("stages: %#v", stages)
+
+	stages1, found := stages.ByTarget("mytarget")
+	if !found {
+		t.Fatal("First target not found")
+	}
+	if len(stages1) != 1 {
+		t.Fatalf("expected 1 stages, got %d", len(stages1))
+	}
+	t.Logf("stages1: %#v", stages1)
+
+	stages2, found := stages.ByTarget("mytarget2")
+	if !found {
+		t.Fatal("Second target not found")
+	}
+	if len(stages2) != 1 {
+		t.Fatalf("expected 1 stages, got %d", len(stages2))
+	}
+	t.Logf("stages2: %#v", stages2)
+}
+
+func TestThroughTarget(t *testing.T) {
+	n, err := ParseFile("dockerclient/testdata/Dockerfile.target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stages, err := NewStages(n, NewBuilder(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 3 {
+		t.Fatalf("expected 3 stages, got %d", len(stages))
+	}
+	t.Logf("stages: %#v", stages)
+
+	stages1, found := stages.ThroughTarget("mytarget")
+	if !found {
+		t.Fatal("First target not found")
+	}
+	if len(stages1) != 2 {
+		t.Fatalf("expected 2 stages, got %d", len(stages1))
+	}
+	t.Logf("stages1: %#v", stages1)
+
+	stages2, found := stages.ThroughTarget("mytarget2")
+	if !found {
+		t.Fatal("Second target not found")
+	}
+	if len(stages2) != 3 {
+		t.Fatalf("expected 3 stages, got %d", len(stages2))
+	}
+	t.Logf("stages2: %#v", stages2)
+}
+
 func TestMultiStageParse(t *testing.T) {
 	n, err := ParseFile("dockerclient/testdata/multistage/Dockerfile")
 	if err != nil {

--- a/dockerclient/testdata/Dockerfile.target
+++ b/dockerclient/testdata/Dockerfile.target
@@ -1,0 +1,8 @@
+FROM ubuntu:latest
+RUN touch /1
+
+FROM alpine:latest AS mytarget 
+RUN touch /2
+
+FROM busybox:latest AS mytarget2 
+RUN touch /3


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

docker build has a --target option that builds the stages from
stage 0 through and including the target specified.  The current
ByTarget() function returns only the specified stage.  The new
ThroughTarget function is heavily based on ByTarget and will now
return the targeted stage plus the prior stages emulating the
docker build --target functionality.

Added tests for both ByTarget and ThroughTarget

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>