### PR TITLE
Use imported constants instead of our own

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -4,10 +4,6 @@ const (
 	// in docker/system
 	NoBaseImageSpecifier = "scratch"
 
-	// not yet part of our import
-	commandArg        = "arg"
-	commandStopSignal = "stopsignal"
-
 	// in docker/system
 	defaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )

--- a/evaluator.go
+++ b/evaluator.go
@@ -20,16 +20,16 @@ func ParseDockerfile(r io.Reader) (*parser.Node, error) {
 
 // Environment variable interpolation will happen on these statements only.
 var replaceEnvAllowed = map[string]bool{
-	command.Env:       true,
-	command.Label:     true,
-	command.Add:       true,
-	command.Copy:      true,
-	command.Workdir:   true,
-	command.Expose:    true,
-	command.Volume:    true,
-	command.User:      true,
-	commandStopSignal: true,
-	commandArg:        true,
+	command.Env:        true,
+	command.Label:      true,
+	command.Add:        true,
+	command.Copy:       true,
+	command.Workdir:    true,
+	command.Expose:     true,
+	command.Volume:     true,
+	command.User:       true,
+	command.StopSignal: true,
+	command.Arg:        true,
 }
 
 // Certain commands are allowed to have their args split into more


### PR DESCRIPTION
We can get `commandArg` and `commandStopSignal` from the updated import, so we don't need to define them ourselves any more.