### PR TITLE
[openshift-3.11] Bug 1730446: dockerclient newArchiveMapper: always end archiveRoot with "/"

### DIFF
--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -357,6 +357,9 @@ func newArchiveMapper(src, dst string, excludes []string, resetOwners bool, chec
 			prefix = path.Base(archiveRoot)
 		}
 	}
+	if !strings.HasSuffix(archiveRoot, "/") {
+		archiveRoot += "/"
+	}
 
 	mapperFn := archivePathMapper(srcPattern, dst, isDestDir)
 

--- a/dockerclient/archive_test.go
+++ b/dockerclient/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -449,8 +450,8 @@ func Test_archiveFromContainer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if path != testCase.path {
-				t.Errorf("unexpected path: %s", path)
+			if filepath.Clean(path) != testCase.path {
+				t.Errorf("unexpected path: %s != %s", filepath.Clean(path), testCase.path)
 			}
 			tr := tar.NewReader(r)
 			var found []string

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -111,6 +111,8 @@ func TestCopyFrom(t *testing.T) {
 		{name: "copy file to deeper directory with explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c/", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
 		{name: "copy file to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
 		{name: "copy directory to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a /a/b/c", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
+		{name: "copy item from directory that is a symbolic link", create: "mkdir -p /a && touch /a/1 && ln -s /a /b", copy: "b/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
+		{name: "copy item from directory that is a symbolic link", create: "mkdir -p /a && touch /a/1 && ln -s a /c", copy: "/c/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
 		{name: "copy directory to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
 		{name: "copy directory trailing to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a/. /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
 	}

--- a/dockerclient/testdata/Dockerfile.copyfrom_11
+++ b/dockerclient/testdata/Dockerfile.copyfrom_11
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+RUN ln -s /a /b
+FROM busybox
+COPY --from=base /b/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/dockerclient/testdata/Dockerfile.copyfrom_12
+++ b/dockerclient/testdata/Dockerfile.copyfrom_12
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+RUN ln -s a /c
+FROM busybox
+COPY --from=base /c/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1


### PR DESCRIPTION
Always end the `archiveRoot` value that we supply as the `Path` for a `DownloadFromContainer` request with a `/`, so that if it refers to a symbolic link, the engine knows we want an archive of the directory that it points to, rather than an archive containing just the symlink.

Cherry-picked from #133, so that we can merge this into origin's 3.11 branch.