### PR TITLE
COPY content of directory to the destination

### DIFF
--- a/dockerclient/copyinfo.go
+++ b/dockerclient/copyinfo.go
@@ -21,7 +21,7 @@ type CopyInfo struct {
 
 // CalcCopyInfo identifies the source files selected by a Dockerfile ADD or COPY instruction.
 func CalcCopyInfo(origPath, rootPath string, allowWildcards bool) ([]CopyInfo, error) {
-	explicitDir := origPath == "." || origPath == "/" || strings.HasSuffix(origPath, "/.") || strings.HasSuffix(origPath, "/")
+	explicitDir := origPath == "." || origPath == "/" || strings.HasSuffix(origPath, "/.")
 	// all CopyInfo resulting from this call will have FromDir set to explicitDir
 	infos, err := calcCopyInfo(origPath, rootPath, allowWildcards, explicitDir)
 	if err != nil {

--- a/dockerclient/copyinfo_test.go
+++ b/dockerclient/copyinfo_test.go
@@ -29,17 +29,24 @@ func TestCalcCopyInfo(t *testing.T) {
 		{
 			origPath:       "*",
 			rootPath:       "testdata/dir",
+			dstPath:        "/",
 			allowWildcards: true,
 			errFn:          nilErr,
 			paths: map[string]struct{}{
 				"Dockerfile": {},
 				"file":       {},
 				"subdir":     {},
+			},
+			rebaseNames: map[string]string{
+				"file":       "/file",
+				"Dockerfile": "/Dockerfile",
+				"subdir":     "/",
 			},
 		},
 		{
 			origPath:       ".",
 			rootPath:       "testdata/dir",
+			dstPath:        "/",
 			allowWildcards: true,
 			errFn:          nilErr,
 			paths: map[string]struct{}{
@@ -47,16 +54,27 @@ func TestCalcCopyInfo(t *testing.T) {
 				"file":       {},
 				"subdir":     {},
 			},
+			rebaseNames: map[string]string{
+				"file":       "/file",
+				"Dockerfile": "/Dockerfile",
+				"subdir":     "/subdir",
+			},
 		},
 		{
 			origPath:       "/.",
 			rootPath:       "testdata/dir",
+			dstPath:        "/",
 			allowWildcards: true,
 			errFn:          nilErr,
 			paths: map[string]struct{}{
 				"Dockerfile": {},
 				"file":       {},
 				"subdir":     {},
+			},
+			rebaseNames: map[string]string{
+				"file":       "/file",
+				"Dockerfile": "/Dockerfile",
+				"subdir":     "/subdir",
 			},
 		},
 		{
@@ -79,7 +97,7 @@ func TestCalcCopyInfo(t *testing.T) {
 		},
 		{
 			origPath:       ".",
-			dstPath:        "copy",
+			dstPath:        "copy/",
 			rootPath:       "testdata/dir",
 			allowWildcards: true,
 			errFn:          nilErr,


### PR DESCRIPTION
Close #139
When COPY multiple files, check if the destination is a directory. If the destinations is not a directory, stop copying. When the source is a directory, copy the contents of the directory to the destination instead of creating the directory.

treat '/' as current workdir.

compatiable with docker
```
$ tree .
.
└── firstdir
    └── seconddir
        ├── dir-a
        │   └── file-a.txt
        └── dir-b
            └── file-b.txt

FROM alpine:3.10
COPY /firstdir/seconddir/ /var
RUN ls -la /var
/var/dir-a/file-a
/var/dir-b/file-b

FROM alpine:3.10
COPY / /var
RUN ls -la /var
/var/firstdir
```

Signed-off-by: Qi Wang <qiwan@redhat.com>