### PR TITLE
Add env to stage

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -212,6 +212,7 @@ func NewStages(node *parser.Node, b *Builder) (Stages, error) {
 			Builder: &Builder{
 				Args:        b.Args,
 				AllowedArgs: b.AllowedArgs,
+				Env:         b.Env,
 			},
 			Node: root,
 		})
@@ -436,7 +437,7 @@ func (b *Builder) FromImage(image *docker.Image, node *parser.Node) error {
 	SplitChildren(node, command.From)
 
 	b.RunConfig = *image.Config
-	b.Env = b.RunConfig.Env
+	b.Env = append(b.Env, b.RunConfig.Env...)
 	b.RunConfig.Env = nil
 
 	// Check to see if we have a default PATH, note that windows won't


### PR DESCRIPTION
Add env from containers.conf to stage so buildah bud can set default env for containers using containers.conf.

PR buildah reads containers.conf https://github.com/containers/buildah/pull/1858

Signed-off-by: Qi Wang <qiwan@redhat.com>