### PR TITLE
NewBuilder(): always initialize Args

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -288,8 +288,12 @@ func NewBuilder(args map[string]string) *Builder {
 	for k, v := range builtinAllowedBuildArgs {
 		allowed[k] = v
 	}
+	provided := make(map[string]string)
+	for k, v := range args {
+		provided[k] = v
+	}
 	return &Builder{
-		Args:        args,
+		Args:        provided,
 		AllowedArgs: allowed,
 	}
 }


### PR DESCRIPTION
We modify the `Args` map member of a Builder object, but we don't make a copy of the initial value that we're given in `NewBuilder()` before doing that, so we end up modifying the map that we're given.  This can be surprising.

In the dispatcher for ARG instructions, we weren't checking that the map wasn't `nil` before attempting to assign values to it, so we could panic, as in https://github.com/openshift/builder/issues/129.

Fix this by making a fresh map in `NewBuilder()` and initializing it using the zero or more values from the passed-in map.