### PR TITLE
Treat args the same way `docker build` does

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -216,7 +216,7 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 
 	// Support ARG before from
 	argStrs := []string{}
-	for n, v := range b.Args {
+	for n, v := range b.HeadingArgs {
 		argStrs = append(argStrs, n+"="+v)
 	}
 	var err error
@@ -598,10 +598,16 @@ func arg(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	// add the arg to allowed list of build-time args from this step on.
 	b.AllowedArgs[name] = true
 
+	// If there is still no default value, a value can be assigned from the heading args
+	if val, ok := b.HeadingArgs[name]; ok && !hasDefault {
+		b.Args[name] = val
+	}
+
 	// If there is a default value associated with this arg then add it to the
-	// b.buildArgs if one is not already passed to the builder. The args passed
-	// to builder override the default value of 'arg'.
-	if _, ok := b.Args[name]; !ok && hasDefault {
+	// b.buildArgs, later default values for the same arg override earlier ones.
+	// The args passed to builder (UserArgs) override the default value of 'arg'
+	// Don't add them here as they were already set in NewBuilder.
+	if _, ok := b.UserArgs[name]; !ok && hasDefault {
 		b.Args[name] = value
 	}
 

--- a/dockerclient/testdata/multistage/Dockerfile.arg-scope
+++ b/dockerclient/testdata/multistage/Dockerfile.arg-scope
@@ -1,0 +1,9 @@
+FROM alpine
+ARG SECRET
+RUN echo "$SECRET"
+
+FROM alpine
+ARG FOO=test
+ARG BAR=bartest
+RUN echo "$FOO:$BAR"
+RUN echo "$SECRET"

--- a/dockerclient/testdata/multistage/Dockerfile.heading-arg
+++ b/dockerclient/testdata/multistage/Dockerfile.heading-arg
@@ -1,5 +1,6 @@
 ARG GO_VERSION=1.9
-FROM golang:$GO_VERSION as builder
+ARG GO_IMAGE=golang
+FROM $GO_IMAGE:$GO_VERSION as builder
 ARG FOO
 WORKDIR /tmp
 COPY . .
@@ -10,7 +11,7 @@ WORKDIR /tmp
 COPY --from=builder /tmp/bar /tmp/bar
 RUN echo foo2 >> /tmp/bar
 
-FROM busybox:latest
+FROM $GO_IMAGE:$GO_VERSION
 WORKDIR /
 COPY --from=modifier /tmp/bar /bin/baz
 

--- a/dockerclient/testdata/multistage/Dockerfile.heading-redefine
+++ b/dockerclient/testdata/multistage/Dockerfile.heading-redefine
@@ -1,0 +1,7 @@
+ARG FOO=latest
+FROM alpine
+RUN echo "$FOO"
+
+FROM centos:$FOO
+ARG FOO
+RUN echo "$FOO"


### PR DESCRIPTION
Before this change a Dockerfile like this:

```
FROM alpine
ARG SECRET
RUN echo $SECRET

FROM alpine
RUN echo "$SECRET" > test_file
```

would expose the arg "SECRET" in every layer of the build.

Now the ARG is only accessible in the layer it is defined.
This gives us parity with the Docker behavior described in
https://docs.docker.com/engine/reference/builder/#scope

"An ARG instruction goes out of scope at the end of the build
stage where it was defined. To use an arg in multiple stages,
each stage must include the ARG instruction."

This was originally reported as https://github.com/containers/buildah/issues/2210
cc @rhatdan 

I wasn't sure how to run the tests locally so I hope this one works... :laughing: 

--------------------------------------------------------------------------------------------------
EDIT:

This PR now attempts to handle all the gaps between `imagebuilder`'s ARG handling and `docker build`'s, one of which was the issue described above and in https://github.com/containers/buildah/issues/2210

I have tried to create test cases or edit existing ones to cover all of the cases, but I'll also list them here.

#### An ARG should only be available after its ARG command in the current stage

This is the original problem, described above. As well as the issue raised by @bparees in https://github.com/openshift/imagebuilder/pull/151#issuecomment-598824416

#### A later ARG default value should override an earlier one in the same stage
```Dockerfile
FROM alpine
ARG FOO=foo
ARG FOO=bar
RUN echo "$FOO"
```
The above Dockerfile should print "bar". Before this patch, the behavior was the opposite, an arg was not changed once set (this old behavior effectively achieved the user-provided case, but the combination of the two necessitated a new Builder struct field for user args).

#### User provided args should override all args default values
```Dockerfile
ARG TAG=latest
FROM centos:$TAG
ARG TAG
RUN echo "$TAG"

FROM alpine
ARG TAG="1.2.3"
RUN echo "$TAG"
```

Building the above Docerfile with `--build-arg TAG=7` should build the first stage from `centos:7` and print "7" in both stages.