### PR TITLE
Fix error output in archive.go

### DIFF
--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -224,7 +224,7 @@ func archiveFromContainer(in io.Reader, src, dst string, excludes []string, chec
 	r, err := transformArchive(in, false, mapper.Filter)
 	rc := readCloser{Reader: r, Closer: newCloser(func() error {
 		if !mapper.foundItems {
-			return fmt.Errorf("%w: %s", os.ErrNotExist, src)
+			return fmt.Errorf("%v: %s", os.ErrNotExist, src)
 		}
 		return nil
 	})}


### PR DESCRIPTION
The dockerclient/archive.go had error output with `%w`
when it should have been `%v`.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>