### PR TITLE
archiveFromContainer(): return possibly-wrapped os.IsNotError

### DIFF
--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -224,7 +224,7 @@ func archiveFromContainer(in io.Reader, src, dst string, excludes []string, chec
 	r, err := transformArchive(in, false, mapper.Filter)
 	rc := readCloser{Reader: r, Closer: newCloser(func() error {
 		if !mapper.foundItems {
-			return fmt.Errorf("%v: %s", os.ErrNotExist, src)
+			return makeNotExistError(src)
 		}
 		return nil
 	})}


### PR DESCRIPTION
When a source specified as a glob can't be found, return an error that can be identified by as an `os.ErrIsNotExist`, wrapped or otherwise, even if we have to drop the glob from the error string to ensure that for versions of Go that don't wrap errors.

Unit tests for the `dockerclient` package were failing with Go 1.12 without this patch.  See the [1.13 release note](https://golang.org/doc/go1.13#error_wrapping) on the use of the `%w` format specifier.
