### PR TITLE
add dockerclient/testdata/Dockerfile.noworkdir

### DIFF
--- a/dockerclient/testdata/Dockerfile.noworkdir
+++ b/dockerclient/testdata/Dockerfile.noworkdir
@@ -1,0 +1,4 @@
+FROM busybox
+WORKDIR /foo
+VOLUME  [ "/foo" ]
+RUN echo


### PR DESCRIPTION
Add a `dockerclient/testdata/Dockerfile.noworkdir` that's referenced by the conformance tests, based on the description in #87.