### PR TITLE
TestDispatchArgDefaultBuiltins: Unbreak on arm

### DIFF
--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -23,7 +23,7 @@ func TestDispatchArgDefaultBuiltins(t *testing.T) {
 	localspec := platforms.DefaultSpec()
 	expectedArgs := []string{
 		"BUILDARCH=" + localspec.Architecture,
-		"TARGETPLATFORM=" + localspec.OS + "/" + localspec.Architecture,
+		"TARGETPLATFORM=" + platforms.DefaultString(),
 	}
 	got := mybuilder.Arguments()
 	sort.Strings(got)


### PR DESCRIPTION
On ARM, the variant is non-empty and reflected in the TARGETPLATFORM default string

Fixes: #160