### PR TITLE
[openshift-3.11] dockerclient: detect ENOENT when copying

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -231,8 +231,12 @@ func NewBuilder(args map[string]string) *Builder {
 	for k, v := range builtinAllowedBuildArgs {
 		allowed[k] = v
 	}
+	provided := make(map[string]string)
+	for k, v := range args {
+		provided[k] = v
+	}
 	return &Builder{
-		Args:        args,
+		Args:        provided,
 		AllowedArgs: allowed,
 	}
 }

--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -205,17 +205,30 @@ func archiveFromFile(file string, src, dst string, excludes []string, check Dire
 	}
 
 	r, err := transformArchive(f, true, mapper.Filter)
-	return r, f, err
+	cc := newCloser(func() error {
+		err := f.Close()
+		if !mapper.foundItems {
+			return makeNotExistError(src)
+		}
+		return err
+	})
+	return r, cc, err
 }
 
-func archiveFromContainer(in io.Reader, src, dst string, excludes []string, check DirectoryCheck) (io.Reader, string, error) {
+func archiveFromContainer(in io.Reader, src, dst string, excludes []string, check DirectoryCheck) (io.ReadCloser, string, error) {
 	mapper, archiveRoot, err := newArchiveMapper(src, dst, excludes, false, check)
 	if err != nil {
 		return nil, "", err
 	}
 
 	r, err := transformArchive(in, false, mapper.Filter)
-	return r, archiveRoot, err
+	rc := readCloser{Reader: r, Closer: newCloser(func() error {
+		if !mapper.foundItems {
+			return fmt.Errorf("%w: %s", os.ErrNotExist, src)
+		}
+		return nil
+	})}
+	return rc, archiveRoot, err
 }
 
 func transformArchive(r io.Reader, compressed bool, fn TransformFileFunc) (io.Reader, error) {
@@ -317,6 +330,7 @@ type archiveMapper struct {
 	rename      func(name string, isDir bool) (string, bool)
 	prefix      string
 	resetOwners bool
+	foundItems  bool
 }
 
 func newArchiveMapper(src, dst string, excludes []string, resetOwners bool, check DirectoryCheck) (*archiveMapper, string, error) {
@@ -396,6 +410,9 @@ func (m *archiveMapper) Filter(h *tar.Header, r io.Reader) ([]byte, bool, bool, 
 	if ok, _ := m.exclude.Matches(h.Name); ok {
 		return nil, false, true, nil
 	}
+
+	m.foundItems = true
+
 	h.Name = newName
 	// include all files
 	return nil, false, false, nil
@@ -499,4 +516,21 @@ func logArchiveOutput(r io.Reader, prefix string) {
 			io.Copy(ioutil.Discard, pr)
 		}
 	}()
+}
+
+type closer struct {
+	closefn func() error
+}
+
+func newCloser(closeFunction func() error) *closer {
+	return &closer{closefn: closeFunction}
+}
+
+func (r *closer) Close() error {
+	return r.closefn()
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
 }

--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -224,7 +224,7 @@ func archiveFromContainer(in io.Reader, src, dst string, excludes []string, chec
 	r, err := transformArchive(in, false, mapper.Filter)
 	rc := readCloser{Reader: r, Closer: newCloser(func() error {
 		if !mapper.foundItems {
-			return fmt.Errorf("%w: %s", os.ErrNotExist, src)
+			return fmt.Errorf("%v: %s", os.ErrNotExist, src)
 		}
 		return nil
 	})}

--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -224,7 +224,7 @@ func archiveFromContainer(in io.Reader, src, dst string, excludes []string, chec
 	r, err := transformArchive(in, false, mapper.Filter)
 	rc := readCloser{Reader: r, Closer: newCloser(func() error {
 		if !mapper.foundItems {
-			return fmt.Errorf("%v: %s", os.ErrNotExist, src)
+			return makeNotExistError(src)
 		}
 		return nil
 	})}

--- a/dockerclient/archive_112.go
+++ b/dockerclient/archive_112.go
@@ -1,0 +1,11 @@
+// +build !go1.13
+
+package dockerclient
+
+import (
+	"os"
+)
+
+func makeNotExistError(s string) error {
+	return os.ErrNotExist
+}

--- a/dockerclient/archive_113.go
+++ b/dockerclient/archive_113.go
@@ -1,0 +1,12 @@
+// +build go1.13
+
+package dockerclient
+
+import (
+	"fmt"
+	"os"
+)
+
+func makeNotExistError(s string) error {
+	return fmt.Errorf("%w: %s", os.ErrNotExist, s)
+}


### PR DESCRIPTION
This patch rolls up changes from #147, #148, #152, and #153.  The latter three aim to be consumable in OpenShift 3.11 to fix https://bugzilla.redhat.com/show_bug.cgi?id=1794768.