### PR TITLE
Handle ARG and ENV with duplicate name on RUN

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -333,9 +333,8 @@ func ParseFile(path string) (*parser.Node, error) {
 // Step creates a new step from the current state.
 func (b *Builder) Step() *Step {
 	dst := make([]string, len(b.Env)+len(b.RunConfig.Env))
-	copy(dst, b.Env)
+	copy(dst, makeUserArgs(b))
 	dst = append(dst, b.RunConfig.Env...)
-	dst = append(dst, b.Arguments()...)
 	return &Step{Env: dst}
 }
 

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -651,28 +651,3 @@ func errTooManyArguments(command string) error {
 func errNotJSON(command string) error {
 	return fmt.Errorf("%s requires the arguments to be in JSON form", command)
 }
-
-// makeUserArgs - Package the variables from the Dockerfile defined by
-// the ENV aand the ARG statements into one slice so the values
-// defined by both can later be evaluated when resolving variables
-// such as ${MY_USER}.  If the variable is defined by both ARG and ENV
-// don't include the definition of the ARG variable.
-func makeUserArgs(b *Builder) (userArgs []string) {
-
-	userArgs = b.Env
-	envMap := make(map[string]string)
-	for _, envVal := range b.Env {
-		val := strings.Split(envVal, "=")
-		if len(val) > 1 {
-			envMap[val[0]] = val[1]
-		}
-	}
-
-	for key, value := range b.Args {
-		if _, ok := envMap[key]; ok {
-			continue
-		}
-		userArgs = append(userArgs, key+"="+value)
-	}
-	return userArgs
-}

--- a/dockerclient/testdata/Dockerfile.envargconflict
+++ b/dockerclient/testdata/Dockerfile.envargconflict
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+# The ARG should be ignored due to the
+# conflict with the ENV declaration.
+ARG USER_NAME=my_user_arg
+ENV USER_NAME=my_user_env
+RUN useradd -r -s /bin/false -m -d /home/${USER_NAME} ${USER_NAME}
+USER ${USER_NAME}
+WORKDIR /home/${USER_NAME}

--- a/internals.go
+++ b/internals.go
@@ -92,3 +92,28 @@ func parseOptInterval(f *flag.Flag) (time.Duration, error) {
 	}
 	return d, nil
 }
+
+// makeUserArgs - Package the variables from the Dockerfile defined by
+// the ENV aand the ARG statements into one slice so the values
+// defined by both can later be evaluated when resolving variables
+// such as ${MY_USER}.  If the variable is defined by both ARG and ENV
+// don't include the definition of the ARG variable.
+func makeUserArgs(b *Builder) (userArgs []string) {
+
+	userArgs = b.Env
+	envMap := make(map[string]string)
+	for _, envVal := range b.Env {
+		val := strings.Split(envVal, "=")
+		if len(val) > 1 {
+			envMap[val[0]] = val[1]
+		}
+	}
+
+	for key, value := range b.Args {
+		if _, ok := envMap[key]; ok {
+			continue
+		}
+		userArgs = append(userArgs, key+"="+value)
+	}
+	return userArgs
+}


### PR DESCRIPTION
If a Dockerfile had an ARG and an ENV with the
same name, things become very unpredictable in
the RUN statement.  This change moves the
code created for handling this same issue in
COPY to the the internals.go file so it
can be used by dispatchers.go and builder.go.

Use the makeUserArgs() function to create a list
of variables, giving precedence to any variables
defined by the ENV statement(s).

This issue was first noted in #159 and once vendored,
this will fix: https://github.com/containers/buildah/issues/2372

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>