### PR TITLE
Handle args with multiple equal signs

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -334,7 +334,7 @@ func ParseFile(path string) (*parser.Node, error) {
 func (b *Builder) Step() *Step {
 	argsMap := make(map[string]string)
 	for _, argsVal := range b.Arguments() {
-		val := strings.Split(argsVal, "=")
+		val := strings.SplitN(argsVal, "=", 2)
 		if len(val) > 1 {
 			argsMap[val[0]] = val[1]
 		}

--- a/dockerclient/testdata/Dockerfile.multiarg
+++ b/dockerclient/testdata/Dockerfile.multiarg
@@ -1,0 +1,4 @@
+FROM alpine
+ARG multivalarg="a=1 b=2 c=3 d=4"
+ENV multival="${multivalarg}"
+RUN echo $multival

--- a/internals.go
+++ b/internals.go
@@ -103,7 +103,7 @@ func makeUserArgs(bEnv []string, bArgs map[string]string) (userArgs []string) {
 	userArgs = bEnv
 	envMap := make(map[string]string)
 	for _, envVal := range bEnv {
-		val := strings.Split(envVal, "=")
+		val := strings.SplitN(envVal, "=", 2)
 		if len(val) > 1 {
 			envMap[val[0]] = val[1]
 		}


### PR DESCRIPTION
If an ARG in a Dockerfile looks like this:

ARG multivalarg="a=1 b=2 c=3 d=4"

the processing would drop everything after the
second equal sign leaving multivalarg="a".

Addresses: https://github.com/containers/buildah/issues/2424

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>