### PR TITLE
Deduplicate environment variables

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -770,7 +770,8 @@ func TestBuilder(t *testing.T) {
 			lastConfig := b.RunConfig
 			if !reflect.DeepEqual(test.Config, lastConfig) {
 				data, _ := json.Marshal(lastConfig)
-				t.Errorf("%d: unexpected config: %s", i, string(data))
+				expected, _ := json.Marshal(test.Config)
+				t.Errorf("%d: unexpected config: %s should be %s", i, string(data), string(expected))
 			}
 		})
 	}

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -83,21 +83,9 @@ func env(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	for j := 0; j < len(args); j++ {
 		// name  ==> args[j]
 		// value ==> args[j+1]
-		newVar := args[j] + "=" + args[j+1] + ""
-		gotOne := false
-		for i, envVar := range b.RunConfig.Env {
-			envParts := strings.SplitN(envVar, "=", 2)
-			if envParts[0] == args[j] {
-				b.RunConfig.Env[i] = newVar
-				b.Env = append([]string{newVar}, b.Env...)
-				gotOne = true
-				break
-			}
-		}
-		if !gotOne {
-			b.RunConfig.Env = append(b.RunConfig.Env, newVar)
-			b.Env = append([]string{newVar}, b.Env...)
-		}
+		newVar := []string{args[j] + "=" + args[j+1]}
+		b.RunConfig.Env = mergeEnv(b.RunConfig.Env, newVar)
+		b.Env = mergeEnv(b.RunConfig.Env, newVar)
 		j++
 	}
 
@@ -153,7 +141,7 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	var chown string
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
-	userArgs := makeUserArgs(b.Env, b.Args)
+	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
@@ -182,7 +170,7 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
 	var chown string
 	var from string
-	userArgs := makeUserArgs(b.Env, b.Args)
+	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {

--- a/internals_test.go
+++ b/internals_test.go
@@ -1,0 +1,77 @@
+package imagebuilder
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestMergeEnv(t *testing.T) {
+	tests := [][3][]string{
+		{
+			[]string{"A=B", "B=C", "C=D"},
+			nil,
+			[]string{"A=B", "B=C", "C=D"},
+		},
+		{
+			nil,
+			[]string{"A=B", "B=C", "C=D"},
+			[]string{"A=B", "B=C", "C=D"},
+		},
+		{
+			[]string{"A=B", "B=C", "C=D", "E=F"},
+			[]string{"B=O", "F=G"},
+			[]string{"A=B", "B=O", "C=D", "E=F", "F=G"},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			result := mergeEnv(test[0], test[1])
+			if len(result) != len(test[2]) {
+				t.Fatalf("expected %v, got %v", test[2], result)
+			}
+			for i := range result {
+				if result[i] != test[2][i] {
+					t.Fatalf("expected %v, got %v", test[2], result)
+				}
+			}
+		})
+	}
+}
+
+func TestEnvMapAsSlice(t *testing.T) {
+	tests := [][2][]string{
+		{
+			[]string{"A=B", "B=C", "C=D"},
+			[]string{"A=B", "B=C", "C=D"},
+		},
+		{
+			[]string{"A=B", "B=C", "C=D", "E=F", "B=O", "F=G"},
+			[]string{"A=B", "B=O", "C=D", "E=F", "F=G"},
+		},
+		{
+			[]string{"A=B", "C=D", "B=C", "E=F", "F=G", "B=O"},
+			[]string{"A=B", "B=O", "C=D", "E=F", "F=G"},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			m := make(map[string]string)
+			for _, spec := range test[0] {
+				s := strings.SplitN(spec, "=", 2)
+				m[s[0]] = s[1]
+			}
+			result := envMapAsSlice(m)
+			sort.Strings(result)
+			if len(result) != len(test[1]) {
+				t.Fatalf("expected %v, got %v", test[1], result)
+			}
+			for i := range result {
+				if result[i] != test[1][i] {
+					t.Fatalf("expected %v, got %v", test[1], result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When building lists of environment variables, or environment variables combined with build arguments, always deduplicate sets of values.  This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1843727.