### PR TITLE
Update parsing of quoted strings

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -518,7 +518,7 @@ func TestBuilder(t *testing.T) {
 			Dockerfile: "dockerclient/testdata/Dockerfile.env",
 			From:       "busybox",
 			Config: docker.Config{
-				Env:   []string{"name=value", "name2=value2a            value2b", "name1=value1", "name3=value3a\\n\"value3b\"", "name4=value4a\\\\nvalue4b"},
+				Env:   []string{"name=value", "name2=value2a            value2b", "name1=value1", "name3=value3a\\n\"value3b\"", "name4=value4a\\nvalue4b"},
 				Image: "busybox",
 			},
 		},

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -770,6 +770,10 @@ func normalizeOutputMetadata(a, b *docker.Config) {
 		// we are forced to set Entrypoint [] to reset the entrypoint
 		b.Entrypoint = nil
 	}
+	if len(a.Labels) == 0 && len(b.Labels) == 0 {
+		a.Labels = nil
+		b.Labels = nil
+	}
 	// Serialization of OnBuild is omitempty, which means it may be nil or empty depending on
 	// docker version
 	if len(a.OnBuild) == len(b.OnBuild) && len(a.OnBuild) == 0 {

--- a/dockerclient/testdata/Dockerfile.env
+++ b/dockerclient/testdata/Dockerfile.env
@@ -9,7 +9,6 @@ ENV name='value"double quote"value2'
 ENV name=value\ value2 name2=value2\ value3
 ENV name="a\"b"
 ENV name="a\'b"
-ENV name='a\'b'
 ENV name='a\'b''
 ENV name='a\"b'
 ENV name="''"


### PR DESCRIPTION
When parsing a single-quoted token, if we reach an EOF before we reach the closing quote, flag it as an error.
When parsing a double-quoted token, accept escaped escape characters ("\\"), and if we reach an EOF before we reach the closing quote, flag it as an error.
This should bring our parsing in line with docker build `17.06` and later.