### PR TITLE
Update conformance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,6 @@ Example of usage from OpenShift's experimental `dockerbuild` [command with mount
 ## Run conformance tests (very slow):
 
 ```
-go test ./dockerclient/conformance_test.go -tags conformance
+chmod -R go-w ./dockerclient/testdata
+go test ./dockerclient/conformance_test.go -tags conformance -timeout 30m
 ```

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -389,8 +389,8 @@ func TestConformanceExternal(t *testing.T) {
 		{
 			Name: "copy and env interaction",
 			// Tests COPY and other complex interactions of ENV
-			ContextDir: "9.3",
-			Dockerfile: "9.3/Dockerfile",
+			ContextDir: "13",
+			Dockerfile: "13/Dockerfile",
 			Git:        "https://github.com/docker-library/postgres.git",
 			Ignore: []ignoreFunc{
 				func(a, b *tar.Header) bool {


### PR DESCRIPTION
The postgres 9.3 build files are no longer at https://github.com/docker-library/postgres; update to use 13.
In `README.md`, suggest taking the group-writable bit off of test data before running conformance tests, and running the tests with a longer-than-default timeout.