### PR TITLE
Dockerfile/parser: Export node.Endline

### DIFF
--- a/dockerfile/parser/parser.go
+++ b/dockerfile/parser/parser.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/openshift/imagebuilder/dockerfile/command"
 	"github.com/docker/docker/pkg/system"
+	"github.com/openshift/imagebuilder/dockerfile/command"
 	"github.com/pkg/errors"
 )
 
@@ -37,7 +37,7 @@ type Node struct {
 	Original   string          // original line used before parsing
 	Flags      []string        // only top Node should have this set
 	StartLine  int             // the line in the original dockerfile where the node begins
-	endLine    int             // the line in the original dockerfile where the node ends
+	EndLine    int             // the line in the original dockerfile where the node ends
 }
 
 // Dump dumps the AST defined by `node` as a list of sexps.
@@ -67,7 +67,7 @@ func (node *Node) Dump() string {
 
 func (node *Node) lines(start, end int) {
 	node.StartLine = start
-	node.endLine = end
+	node.EndLine = end
 }
 
 // AddChild adds a new child node, and updates line information
@@ -76,7 +76,7 @@ func (node *Node) AddChild(child *Node, startLine, endLine int) {
 	if node.StartLine < 0 {
 		node.StartLine = startLine
 	}
-	node.endLine = endLine
+	node.EndLine = endLine
 	node.Children = append(node.Children, child)
 }
 

--- a/dockerfile/parser/parser_test.go
+++ b/dockerfile/parser/parser_test.go
@@ -115,7 +115,7 @@ func TestParseIncludesLineNumbers(t *testing.T) {
 
 	ast := result.AST
 	assert.Equal(t, 5, ast.StartLine)
-	assert.Equal(t, 31, ast.endLine)
+	assert.Equal(t, 31, ast.EndLine)
 	assert.Len(t, ast.Children, 3)
 	expected := [][]int{
 		{5, 5},
@@ -124,7 +124,7 @@ func TestParseIncludesLineNumbers(t *testing.T) {
 	}
 	for i, child := range ast.Children {
 		msg := fmt.Sprintf("Child %d", i)
-		assert.Equal(t, expected[i], []int{child.StartLine, child.endLine}, msg)
+		assert.Equal(t, expected[i], []int{child.StartLine, child.EndLine}, msg)
 	}
 }
 


### PR DESCRIPTION
It might be useful for consumers to know the Endline. Today, it can be
derived from looking at the StartLine of the following Node or
defaulting to the last line of the Dockerfile, but that is cumbersome.