### PR TITLE
[release-3.11] support comments in .dockerignore

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -474,14 +474,21 @@ var builtinAllowedBuildArgs = map[string]bool{
 }
 
 // ParseDockerIgnore returns a list of the excludes in the .dockerignore file.
-// extracted from fsouza/go-dockerclient.
+// extracted from fsouza/go-dockerclient and modified to drop comments and
+// empty lines.
 func ParseDockerignore(root string) ([]string, error) {
 	var excludes []string
 	ignore, err := ioutil.ReadFile(filepath.Join(root, ".dockerignore"))
 	if err != nil && !os.IsNotExist(err) {
 		return excludes, fmt.Errorf("error reading .dockerignore: '%s'", err)
 	}
-	return strings.Split(string(ignore), "\n"), nil
+	for _, e := range strings.Split(string(ignore), "\n") {
+		if len(e) == 0 || e[0] == '#' {
+			continue
+		}
+		excludes = append(excludes, e)
+	}
+	return excludes, nil
 }
 
 // ExportEnv creates an export statement for a shell that contains all of the

--- a/builder_test.go
+++ b/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -425,5 +426,59 @@ func TestBuilder(t *testing.T) {
 				t.Errorf("%d: unexpected config: %s", i, string(data))
 			}
 		})
+	}
+}
+
+func TestParseDockerignore(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dockerignore*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	tests := []struct {
+		input, result []string
+	}{
+		{
+			input:  []string{"first", "second", "", "third", "fourth"},
+			result: []string{"first", "second", "third", "fourth"},
+		},
+		{
+			input:  []string{"#first", "#second", "", "third", "fourth"},
+			result: []string{"third", "fourth"},
+		},
+		{
+			input:  []string{"", "first", "second", "", " #third", "#invalid pattern which shouldn't matter ("},
+			result: []string{"first", "second", " #third"},
+		},
+		{
+			input:  []string{"", "first", "second", "", "#third", ""},
+			result: []string{"first", "second"},
+		},
+		{
+			input:  []string{"first", "second", "", "th#rd", "fourth", "fifth#"},
+			result: []string{"first", "second", "th#rd", "fourth", "fifth#"},
+		},
+	}
+	dockerignore := filepath.Join(dir, ".dockerignore")
+	for _, test := range tests {
+		f, err := os.Create(dockerignore)
+		if err != nil {
+			t.Fatalf("error creating %q: %v", dockerignore, err)
+		}
+		fmt.Fprintf(f, "%s\n", strings.Join(test.input, "\n"))
+		f.Close()
+		excludes, err := ParseDockerignore(dir)
+		if err != nil {
+			t.Fatalf("error reading %q: %v", dockerignore, err)
+		}
+		if len(excludes) != len(test.result) {
+			t.Errorf("expected to read back %#v, got %#v", test.result, excludes)
+		}
+		for i := range excludes {
+			if excludes[i] != test.result[i] {
+				t.Errorf("expected to read back %#v, got %#v", test.result, excludes)
+			}
+		}
 	}
 }


### PR DESCRIPTION
When reading the contents of .dockerignore, filter out empty lines and lines that have a '#' as their first character, from #177.