### PR TITLE
ADD: add another conformance test

### DIFF
--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -313,6 +313,11 @@ func TestConformanceInternal(t *testing.T) {
 			Dockerfile: "Dockerfile.copy",
 		},
 		{
+			Name:       "add directories with archives",
+			ContextDir: "testdata/add",
+			Dockerfile: "Dockerfile.addall",
+		},
+		{
 			Name:       "run with JSON",
 			Dockerfile: "testdata/Dockerfile.run.args",
 			Output: []*regexp.Regexp{

--- a/dockerclient/testdata/add/Dockerfile.addall
+++ b/dockerclient/testdata/add/Dockerfile.addall
@@ -1,0 +1,2 @@
+FROM centos:7
+ADD . .


### PR DESCRIPTION
Make sure that when we're extracting archives that are ADDed, we don't extract archives under a directory that we're ADDing, so that we won't need a fix like https://github.com/containers/buildah/pull/2667 in the future.