### PR TITLE
Support .containerignore as well as .dockerignore

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -562,14 +562,16 @@ var builtinAllowedBuildArgs = map[string]bool{
 	"no_proxy":    true,
 }
 
-// ParseDockerIgnore returns a list of the excludes in the .dockerignore file.
+// ParseIgnore returns a list of the excludes in the specified path
+// path should be a file with the .dockerignore format
 // extracted from fsouza/go-dockerclient and modified to drop comments and
 // empty lines.
-func ParseDockerignore(root string) ([]string, error) {
+func ParseIgnore(path string) ([]string, error) {
 	var excludes []string
-	ignore, err := ioutil.ReadFile(filepath.Join(root, ".dockerignore"))
-	if err != nil && !os.IsNotExist(err) {
-		return excludes, fmt.Errorf("error reading .dockerignore: '%s'", err)
+
+	ignore, err := ioutil.ReadFile(path)
+	if err != nil {
+		return excludes, err
 	}
 	for _, e := range strings.Split(string(ignore), "\n") {
 		if len(e) == 0 || e[0] == '#' {
@@ -578,6 +580,18 @@ func ParseDockerignore(root string) ([]string, error) {
 		excludes = append(excludes, e)
 	}
 	return excludes, nil
+}
+
+// ParseDockerIgnore returns a list of the excludes in the .containerignore or .dockerignore file.
+func ParseDockerignore(root string) ([]string, error) {
+	excludes, err := ParseIgnore(filepath.Join(root, ".containerignore"))
+	if err != nil && os.IsNotExist(err) {
+		excludes, err = ParseIgnore(filepath.Join(root, ".dockerignore"))
+	}
+	if err != nil && os.IsNotExist(err) {
+		return excludes, nil
+	}
+	return excludes, err
 }
 
 // ExportEnv creates an export statement for a shell that contains all of the

--- a/builder.go
+++ b/builder.go
@@ -569,15 +569,18 @@ var builtinAllowedBuildArgs = map[string]bool{
 func ParseIgnore(path string) ([]string, error) {
 	var excludes []string
 
-	ignore, err := ioutil.ReadFile(path)
+	ignores, err := ioutil.ReadFile(path)
 	if err != nil {
 		return excludes, err
 	}
-	for _, e := range strings.Split(string(ignore), "\n") {
-		if len(e) == 0 || e[0] == '#' {
+	for _, ignore := range strings.Split(string(ignores), "\n") {
+		if len(ignore) == 0 || ignore[0] == '#' {
 			continue
 		}
-		excludes = append(excludes, e)
+		ignore = strings.Trim(ignore, "/")
+		if len(ignore) > 0 {
+			excludes = append(excludes, ignore)
+		}
 	}
 	return excludes, nil
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -889,17 +889,57 @@ func TestParseDockerignore(t *testing.T) {
 			result: []string{"first", "second", "th#rd", "fourth", "fifth#"},
 		},
 	}
-	dockerignore := filepath.Join(dir, ".dockerignore")
+
+	testIgnore := func(ignorefile string) {
+		for _, test := range tests {
+			f, err := os.Create(ignorefile)
+			if err != nil {
+				t.Fatalf("error creating %q: %v", ignorefile, err)
+			}
+			fmt.Fprintf(f, "%s\n", strings.Join(test.input, "\n"))
+			f.Close()
+			excludes, err := ParseDockerignore(dir)
+			if err != nil {
+				t.Fatalf("error reading %q: %v", ignorefile, err)
+			}
+			if err := os.Remove(ignorefile); err != nil {
+				t.Fatalf("failed to remove ignore file: %v", err)
+			}
+			if len(excludes) != len(test.result) {
+				t.Errorf("expected to read back %#v, got %#v", test.result, excludes)
+			}
+			for i := range excludes {
+				if excludes[i] != test.result[i] {
+					t.Errorf("expected to read back %#v, got %#v", test.result, excludes)
+				}
+			}
+		}
+	}
+	testIgnore(filepath.Join(dir, ".containerignore"))
+	testIgnore(filepath.Join(dir, ".dockerignore"))
+	// Create empty .dockerignore to test in same directory as .containerignore
+	f, err := os.Create(filepath.Join(dir, ".dockerignore"))
+	if err != nil {
+		t.Fatalf("error creating: %v", err)
+	}
+	f.Close()
+	testIgnore(filepath.Join(dir, ".containerignore"))
+	os.Remove(filepath.Join(dir, ".dockerignore"))
+
+	ignorefile := filepath.Join(dir, "ignore")
 	for _, test := range tests {
-		f, err := os.Create(dockerignore)
+		f, err := os.Create(ignorefile)
 		if err != nil {
-			t.Fatalf("error creating %q: %v", dockerignore, err)
+			t.Fatalf("error creating %q: %v", ignorefile, err)
 		}
 		fmt.Fprintf(f, "%s\n", strings.Join(test.input, "\n"))
 		f.Close()
-		excludes, err := ParseDockerignore(dir)
+		excludes, err := ParseIgnore(ignorefile)
 		if err != nil {
-			t.Fatalf("error reading %q: %v", dockerignore, err)
+			t.Fatalf("error reading %q: %v", ignorefile, err)
+		}
+		if err := os.Remove(ignorefile); err != nil {
+			t.Fatalf("failed to remove ignore file: %v", err)
 		}
 		if len(excludes) != len(test.result) {
 			t.Errorf("expected to read back %#v, got %#v", test.result, excludes)

--- a/builder_test.go
+++ b/builder_test.go
@@ -888,6 +888,10 @@ func TestParseDockerignore(t *testing.T) {
 			input:  []string{"first", "second", "", "th#rd", "fourth", "fifth#"},
 			result: []string{"first", "second", "th#rd", "fourth", "fifth#"},
 		},
+		{
+			input:  []string{"/first", "second/", "/third/", "///fourth//", "fif/th#", "/"},
+			result: []string{"first", "second", "third", "fourth", "fif/th#"},
+		},
 	}
 
 	testIgnore := func(ignorefile string) {


### PR DESCRIPTION
We have been asked in buildah to have containerignore as an alternative
name for dockerignore, similer to Containerfile versus Dockerfile.

This pr will look for .containerfile first and then fail over to
.dockerignore.

We also want to add a new feature to support
buildah bud -f FILENAME.dockerignore /tmp

This is a new feature of Docker to allow people to create a file
with .dockerignore postfix, instead of just looking for .dockerignore

Ignore begining or trailing '/' in ignore line

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>