### PR TITLE
README.txt: correct the suggested invocation for conformance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Example of usage from OpenShift's experimental `dockerbuild` [command with mount
 ## Run conformance tests (very slow):
 
 ```
+docker rmi busybox; docker pull busybox
+docker rmi centos:7; docker pull centos:7
 chmod -R go-w ./dockerclient/testdata
-go test ./dockerclient/conformance_test.go -tags conformance -timeout 30m
+go test ./dockerclient -tags conformance -timeout 30m
 ```


### PR DESCRIPTION
The conformance tests shouldn't be run against a single source file, but rather the package that contains them.