### PR TITLE
dockerclient/testdata/copychown/Dockerfile: remove an irrelevant instruction

### DIFF
--- a/dockerclient/testdata/copychown/Dockerfile
+++ b/dockerclient/testdata/copychown/Dockerfile
@@ -8,4 +8,3 @@ COPY --chown=2      script /usr/bin/script.2
 COPY --chown=bin    script /usr/bin/script.bin
 COPY --chown=lp     script /usr/bin/script.lp
 COPY --chown=3      script script2 /usr/local/bin/
-RUN ls -al /usr/bin/script


### PR DESCRIPTION
Running "ls" on the /usr/bin/script provided by util-linux doesn't contribute anything to this test, so don't bother with that.