### PR TITLE
Add mounts to dispatch run

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -37,6 +37,8 @@ type Copy struct {
 type Run struct {
 	Shell bool
 	Args  []string
+	// Mounts are mounts specified through the --mount flag inside the Containerfile
+	Mounts []string
 }
 
 type Executor interface {
@@ -67,7 +69,7 @@ func (logExecutor) Copy(excludes []string, copies ...Copy) error {
 }
 
 func (logExecutor) Run(run Run, config docker.Config) error {
-	log.Printf("RUN %v %t (%v)", run.Args, run.Shell, config.Env)
+	log.Printf("RUN %v %v %t (%v)", run.Args, run.Mounts, run.Shell, config.Env)
 	return nil
 }
 

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -306,7 +306,26 @@ func run(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 
 	args = handleJSONArgs(args, attributes)
 
-	run := Run{Args: args}
+	var mounts []string
+	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	for _, a := range flagArgs {
+		arg, err := ProcessWord(a, userArgs)
+		if err != nil {
+			return err
+		}
+		switch {
+		case strings.HasPrefix(arg, "--mount="):
+			mount := strings.TrimPrefix(arg, "--mount=")
+			mounts = append(mounts, mount)
+		default:
+			return fmt.Errorf("RUN only supports the --mount flag")
+		}
+	}
+
+	run := Run{
+		Args:   args,
+		Mounts: mounts,
+	}
 
 	if !attributes["json"] {
 		run.Shell = true

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -630,3 +630,33 @@ func TestDispatchAddChmod(t *testing.T) {
 		t.Errorf("Expected %v, to match %v\n", expectedPendingCopies, mybuilder2.PendingCopies)
 	}
 }
+
+func TestDispatchRunFlags(t *testing.T) {
+	mybuilder := Builder{
+		RunConfig: docker.Config{
+			WorkingDir: "/root",
+			Cmd:        []string{"/bin/sh"},
+			Image:      "busybox",
+		},
+	}
+
+	flags := []string{"--mount=type=bind,target=/foo"}
+	args := []string{"echo \"stuff\""}
+	original := "RUN --mount=type=bind,target=/foo echo \"stuff\""
+
+	if err := run(&mybuilder, args, nil, flags, original); err != nil {
+		t.Errorf("dispatchAdd error: %v", err)
+	}
+	expectedPendingRuns := []Run{
+		{
+			Shell:  true,
+			Args:   args,
+			Mounts: []string{"type=bind,target=/foo"},
+		},
+	}
+
+	if !reflect.DeepEqual(mybuilder.PendingRuns, expectedPendingRuns) {
+		t.Errorf("Expected %v, to match %v\n", expectedPendingRuns, mybuilder.PendingRuns)
+	}
+
+}


### PR DESCRIPTION
parse build mounts RUN --mount=...
the RUN command can take flags from the dockerfile.

needed for https://github.com/containers/buildah/issues/1684

Signed-off-by: Ashley Cui <acui@redhat.com>