### PR TITLE
Handle COPY --from=${number}

### DIFF
--- a/dockerclient/testdata/Dockerfile.copyfrom_13
+++ b/dockerclient/testdata/Dockerfile.copyfrom_13
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN touch /a
+FROM busybox
+COPY --from=0 /a /
+RUN ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_14
+++ b/dockerclient/testdata/Dockerfile.copyfrom_14
@@ -1,0 +1,5 @@
+FROM busybox
+RUN touch /a
+FROM busybox
+COPY --from=0 /a /
+RUN ls -al /a


### PR DESCRIPTION
Handle COPY --from=${stage} where the referred-to stage is referred to by its order in the build, and add a couple of test Dockerfiles that test COPY --from=${stage}, where ${stage} is a number.  Conformance tests don't currently handle multi-stage builds, but we add a couple of samples for manual smoke testers.