### PR TITLE
archiveFromDisk: inline archives that are being ADDed

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -1079,28 +1079,6 @@ func (e *ClientExecutor) Archive(fromFS bool, src, dst string, allowDownload boo
 		klog.V(5).Infof("Archiving %s %s -> %s from context archive", e.ContextArchive, src, dst)
 		return archiveFromFile(e.ContextArchive, src, dst, excludes, check)
 	}
-	// if the source is an archive, extract it under the destination directory
-	srcFullPath := filepath.Join(e.Directory, src)
-	if allowDownload && isArchivePath(srcFullPath) {
-		f, err := os.Open(srcFullPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error opening %q: %v", srcFullPath, err)
-		}
-		klog.V(5).Infof("Extracting %s -> %s from local archive", srcFullPath, dst)
-		transform := func(h *tar.Header, r io.Reader) (data []byte, update bool, skip bool, err error) {
-			h.Name = filepath.Join(dst, h.Name)
-			if h.Typeflag == tar.TypeLink {
-				h.Linkname = filepath.Join(dst, h.Linkname)
-			}
-			return nil, false, false, nil
-		}
-		filtered, err := transformArchive(f, true, transform)
-		if err != nil {
-			f.Close()
-			return nil, nil, fmt.Errorf("error transforming archive %q: %v", srcFullPath, err)
-		}
-		return filtered, f, nil
-	}
 	// if the context is a directory, we only allow relative includes
 	klog.V(5).Infof("Archiving %q %q -> %q from disk", e.Directory, src, dst)
 	return archiveFromDisk(e.Directory, src, dst, allowDownload, excludes, check)

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -347,6 +347,11 @@ func TestConformanceInternal(t *testing.T) {
 			Dockerfile: "Dockerfile.addall",
 		},
 		{
+			Name:       "add directories with archives 2",
+			ContextDir: "testdata/add",
+			Dockerfile: "Dockerfile.addslash",
+		},
+		{
 			Name:       "run with JSON",
 			Dockerfile: "testdata/Dockerfile.run.args",
 			Output: []*regexp.Regexp{
@@ -432,8 +437,8 @@ func TestConformanceExternal(t *testing.T) {
 		{
 			Name: "copy and env interaction",
 			// Tests COPY and other complex interactions of ENV
-			ContextDir: "13",
-			Dockerfile: "13/Dockerfile",
+			ContextDir: "13/alpine",
+			Dockerfile: "13/alpine/Dockerfile",
 			Git:        "https://github.com/docker-library/postgres.git",
 			Ignore: []ignoreFunc{
 				func(a, b *tar.Header) bool {

--- a/dockerclient/testdata/add/Dockerfile
+++ b/dockerclient/testdata/add/Dockerfile
@@ -6,3 +6,8 @@ ADD archived.tar.bz2 /archived-bz2/
 ADD archived.tar.xz /archived-xz/
 ADD archived.txt archived.tar.xz archived.tar.bz2 /archived-mixed/
 ADD archived.txt /archived.tar.xz ./archived.tar.bz2 /archived-mixed-path-variations/
+ADD archived.txt*     /archived-globbed-plain/
+ADD archived.tar.gz*  /archived-globbed-gz/
+ADD archived.tar.bz2* /archived-globbed-bz2/
+ADD archived.tar.xz*  /archived-globbed-xz/
+ADD archived.*        /archived-globbed/

--- a/dockerclient/testdata/add/Dockerfile.addslash
+++ b/dockerclient/testdata/add/Dockerfile.addslash
@@ -1,0 +1,2 @@
+FROM centos:7
+ADD / /


### PR DESCRIPTION
Remove the attempt to handle archives from ClientExecutor.Archive(), which couldn't handle sources specified using globbing patterns, and move that logic into archiveFromDisk(), which handles the globbing.

Fixes #194.