### PR TITLE
calcCopyInfo: also trim leading path on rootPath

### DIFF
--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -257,6 +257,10 @@ func TestMultiStageBase(t *testing.T) {
 // TODO: ensure that the final built image has the right UIDs
 //
 func TestConformanceInternal(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
 	testCases := []conformanceTest{
 		{
 			Name:       "directory",
@@ -379,6 +383,14 @@ func TestConformanceInternal(t *testing.T) {
 		{
 			Name:       "wildcard",
 			ContextDir: "testdata/wildcard",
+		},
+		{
+			Name:       "wildcard leading path",
+			ContextDir: "./testdata/wildcard",
+		},
+		{
+			Name:       "wildcard absolute path",
+			ContextDir: filepath.Join(pwd, "testdata", "wildcard"),
 		},
 		{
 			Name:       "volume",

--- a/dockerclient/copyinfo.go
+++ b/dockerclient/copyinfo.go
@@ -32,6 +32,9 @@ func CalcCopyInfo(origPath, rootPath string, allowWildcards bool) ([]CopyInfo, e
 
 func calcCopyInfo(origPath, rootPath string, allowWildcards, explicitDir bool) ([]CopyInfo, error) {
 	origPath = trimLeadingPath(origPath)
+	if !filepath.IsAbs(rootPath) {
+		rootPath = trimLeadingPath(rootPath)
+	}
 	// Deal with wildcards
 	if allowWildcards && containsWildcards(origPath) {
 		matchPath := filepath.Join(rootPath, origPath)


### PR DESCRIPTION
calcCopyInfo trims a leading "./" or "/./" from one of its parameters, but not the other, which can break COPY instructions when the build context location is specified using a path that starts with "./".