### PR TITLE
Avoid panic when writing UIDs/GIDs > 0x1fffff

### DIFF
--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -576,8 +576,8 @@ func (m *archiveMapper) Filter(h *tar.Header, r io.Reader) ([]byte, bool, bool, 
 					rehdr, err = tr2.Next()
 				}
 				if err != nil {
-					return nil, false, true, fmt.Errorf("needed to create %q as a hard link to %q, but got error refetching %q: %v", h.Name, h.Linkname, h.Linkname, err)
 					pr.Close()
+					return nil, false, true, fmt.Errorf("needed to create %q as a hard link to %q, but got error refetching %q: %v", h.Name, h.Linkname, h.Linkname, err)
 				}
 				buf, err := ioutil.ReadAll(pr)
 				pr.Close()

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -116,7 +116,7 @@ type ClientExecutor struct {
 	Volumes *ContainerVolumeTracker
 }
 
-// NotAuthFn can be used for AuthFn when no authentication is required in Docker.
+// NoAuthFn can be used for AuthFn when no authentication is required in Docker.
 func NoAuthFn(string) ([]dockertypes.AuthConfig, bool) {
 	return nil, false
 }
@@ -807,6 +807,9 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 		}
 		if chownGid != -1 {
 			h.Gid = chownGid
+		}
+		if err := forceHeaderFormat(h); err != nil {
+			return nil, false, false, nil
 		}
 		return nil, false, false, nil
 	}

--- a/dockerclient/client_110.go
+++ b/dockerclient/client_110.go
@@ -1,0 +1,12 @@
+// +build go1.10
+
+package dockerclient
+
+import "archive/tar"
+
+func forceHeaderFormat(h *tar.Header) error {
+	if (h.Uid > 0x1fffff || h.Gid > 0x1fffff) && h.Format == tar.FormatUSTAR {
+		h.Format = tar.FormatPAX
+	}
+	return nil
+}

--- a/dockerclient/client_19.go
+++ b/dockerclient/client_19.go
@@ -1,0 +1,9 @@
+// +build !go1.10
+
+package dockerclient
+
+import "archive/tar"
+
+func forceHeaderFormat(h *tar.Header) error {
+	return nil
+}


### PR DESCRIPTION
The USTAR archive format can't encode UIDs or GIDs that can't be represented in 21 (7 * 3) bits, which creates errors when we modify headers to include such values.  When we do that, try to force a conversion to the PAX format, which can handle that.

This requires Go 1.10 or later, as the constants which need to be set in the header to indicate the format which should be used weren't exported before that.

Fixes #200.