### PR TITLE
COPY --chown: add missing parent directories

### DIFF
--- a/dockerclient/testdata/copychown/Dockerfile
+++ b/dockerclient/testdata/copychown/Dockerfile
@@ -1,10 +1,20 @@
 FROM centos:7
-COPY --chown=1:2    script /usr/bin/script.12
-COPY --chown=1:adm  script /usr/bin/script.1-adm
-COPY --chown=1      script /usr/bin/script.1
-COPY --chown=lp:adm script /usr/bin/script.lp-adm
-COPY --chown=2:mail script /usr/bin/script.2-mail
-COPY --chown=2      script /usr/bin/script.2
-COPY --chown=bin    script /usr/bin/script.bin
-COPY --chown=lp     script /usr/bin/script.lp
-COPY --chown=3      script script2 /usr/local/bin/
+COPY --chown=1:2     script /usr/bin/script.12
+COPY --chown=1:adm   script /usr/bin/script.1-adm
+COPY --chown=1       script /usr/bin/script.1
+COPY --chown=lp:adm  script /usr/bin/script.lp-adm
+COPY --chown=2:mail  script /usr/bin/script.2-mail
+COPY --chown=2       script /usr/bin/script.2
+COPY --chown=bin     script /usr/bin/script.bin
+COPY --chown=lp      script /usr/bin/script.lp
+COPY --chown=3       script script2 /usr/local/bin/
+RUN  rm -fr /var/created-directory
+COPY --chown=2097152 script script2 /var/created/directory/
+RUN  rm -fr /no-such-directory
+COPY --chown=3       script script2 /no-such-directory/
+RUN  rm -fr /new-workdir
+WORKDIR /new-workdir/several/levels/deep
+COPY --chown=3       script script2 no-such-directory/
+WORKDIR ../deeper
+COPY --chown=3       script script2 no-such-directory-either/
+COPY --chown=3       script script2 ../no-such-subdirectory/


### PR DESCRIPTION
When we let the daemon implicitly create not-yet-created parent directories when we COPY in content that is to be owned by a non-root user, the daemon doesn't know that newly-created directories also need to be owned by that non-root user, so it creates them owned by root, which is wrong.

When we're using COPY with --chown, check for the destination path for any copy being missing, and add any missing path components as directories.  If the path is a destination file, it'll be overwritten by the file.  This is pretty expensive, though, so don't do it unless we have to.

In `TestConformanceInternal/copy chown`, test `--chown` with a value larger than we can represent in 21 bits, so that `forceHeaderFormat()` will be invoked, to test #205.