### PR TITLE
ARG: allows to process multiple `ARGS` in single step

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -328,6 +328,18 @@ func TestArgs(t *testing.T) {
 			expectedValue: "FOO=bar",
 		},
 		{
+			name:          "multiple args in single step",
+			dockerfile:    "FROM centos\nARG FOO=stuff WORLD=hello\n",
+			args:          map[string]string{},
+			expectedValue: "WORLD=hello",
+		},
+		{
+			name:          "multiple args in single step",
+			dockerfile:    "FROM centos\nARG FOO=stuff WORLD=hello\n",
+			args:          map[string]string{},
+			expectedValue: "FOO=stuff",
+		},
+		{
 			name:          "headingArgRedefine",
 			dockerfile:    "ARG FOO=stuff\nFROM centos\nARG FOO\n",
 			args:          map[string]string{},

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -573,65 +573,63 @@ var targetArgs = []string{"TARGETOS", "TARGETARCH", "TARGETVARIANT"}
 // to builder using the --build-arg flag for expansion/subsitution or passing to 'run'.
 // Dockerfile author may optionally set a default value of this variable.
 func arg(b *Builder, args []string, attributes map[string]bool, flagArgs []string, original string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("ARG requires exactly one argument definition")
-	}
-
 	var (
 		name       string
 		value      string
 		hasDefault bool
 	)
 
-	arg := args[0]
-	// 'arg' can just be a name or name-value pair. Note that this is different
-	// from 'env' that handles the split of name and value at the parser level.
-	// The reason for doing it differently for 'arg' is that we support just
-	// defining an arg and not assign it a value (while 'env' always expects a
-	// name-value pair). If possible, it will be good to harmonize the two.
-	if strings.Contains(arg, "=") {
-		parts := strings.SplitN(arg, "=", 2)
-		name = parts[0]
-		value = parts[1]
-		hasDefault = true
-		if name == "TARGETPLATFORM" {
-			p, err := platforms.Parse(value)
-			if err != nil {
-				return fmt.Errorf("error parsing TARGETPLATFORM argument")
+	for _, argument := range args {
+		arg := argument
+		// 'arg' can just be a name or name-value pair. Note that this is different
+		// from 'env' that handles the split of name and value at the parser level.
+		// The reason for doing it differently for 'arg' is that we support just
+		// defining an arg and not assign it a value (while 'env' always expects a
+		// name-value pair). If possible, it will be good to harmonize the two.
+		if strings.Contains(arg, "=") {
+			parts := strings.SplitN(arg, "=", 2)
+			name = parts[0]
+			value = parts[1]
+			hasDefault = true
+			if name == "TARGETPLATFORM" {
+				p, err := platforms.Parse(value)
+				if err != nil {
+					return fmt.Errorf("error parsing TARGETPLATFORM argument")
+				}
+				for _, val := range targetArgs {
+					b.AllowedArgs[val] = true
+				}
+				b.Args["TARGETPLATFORM"] = p.OS + "/" + p.Architecture
+				b.Args["TARGETOS"] = p.OS
+				b.Args["TARGETARCH"] = p.Architecture
+				b.Args["TARGETVARIANT"] = p.Variant
+				if p.Variant != "" {
+					b.Args["TARGETPLATFORM"] = b.Args["TARGETPLATFORM"] + "/" + p.Variant
+				}
 			}
-			for _, val := range targetArgs {
-				b.AllowedArgs[val] = true
-			}
-			b.Args["TARGETPLATFORM"] = p.OS + "/" + p.Architecture
-			b.Args["TARGETOS"] = p.OS
-			b.Args["TARGETARCH"] = p.Architecture
-			b.Args["TARGETVARIANT"] = p.Variant
-			if p.Variant != "" {
-				b.Args["TARGETPLATFORM"] = b.Args["TARGETPLATFORM"] + "/" + p.Variant
-			}
+		} else if val, ok := builtinBuildArgs[arg]; ok {
+			name = arg
+			value = val
+			hasDefault = true
+		} else {
+			name = arg
+			hasDefault = false
 		}
-	} else if val, ok := builtinBuildArgs[arg]; ok {
-		name = arg
-		value = val
-		hasDefault = true
-	} else {
-		name = arg
-		hasDefault = false
-	}
-	// add the arg to allowed list of build-time args from this step on.
-	b.AllowedArgs[name] = true
+		// add the arg to allowed list of build-time args from this step on.
+		b.AllowedArgs[name] = true
 
-	// If there is still no default value, a value can be assigned from the heading args
-	if val, ok := b.HeadingArgs[name]; ok && !hasDefault {
-		b.Args[name] = val
-	}
+		// If there is still no default value, a value can be assigned from the heading args
+		if val, ok := b.HeadingArgs[name]; ok && !hasDefault {
+			b.Args[name] = val
+		}
 
-	// If there is a default value associated with this arg then add it to the
-	// b.buildArgs, later default values for the same arg override earlier ones.
-	// The args passed to builder (UserArgs) override the default value of 'arg'
-	// Don't add them here as they were already set in NewBuilder.
-	if _, ok := b.UserArgs[name]; !ok && hasDefault {
-		b.Args[name] = value
+		// If there is a default value associated with this arg then add it to the
+		// b.buildArgs, later default values for the same arg override earlier ones.
+		// The args passed to builder (UserArgs) override the default value of 'arg'
+		// Don't add them here as they were already set in NewBuilder.
+		if _, ok := b.UserArgs[name]; !ok && hasDefault {
+			b.Args[name] = value
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Allows imagebuilder to process multiple args in a single step since
docker supports that.

Usage

```dockerfile
FROM alpine
ARG foo=0 bar=1
RUN echo $foo, $bar
```

Closes: https://github.com/containers/buildah/issues/3737