### PR TITLE
dockerclient: copying a directory from another stage should discard perms

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -304,7 +304,7 @@ type Builder struct {
 
 	Warnings []string
 	// Raw platform string specified with `FROM --platform` of the stage
-	// Its up to the implementation or client to parse and use this field
+	// It's up to the implementation or client to parse and use this field
 	Platform string
 }
 
@@ -473,7 +473,7 @@ func (b *Builder) FromImage(image *docker.Image, node *parser.Node) error {
 	b.RunConfig.Env = nil
 
 	// Check to see if we have a default PATH, note that windows won't
-	// have one as its set by HCS
+	// have one as it's set by HCS
 	if runtime.GOOS != "windows" && !hasEnvName(b.Env, "PATH") {
 		b.RunConfig.Env = append(b.RunConfig.Env, "PATH="+defaultPathEnv)
 	}

--- a/dockerclient/testdata/copyfrom/Dockerfile
+++ b/dockerclient/testdata/copyfrom/Dockerfile
@@ -1,4 +1,15 @@
 FROM centos:7 as base
 RUN mkdir -p /a/blah && touch /a/blah/1 /a/blah/2
+RUN mkdir -m 711 /711 && touch /711/711.txt
+RUN mkdir -m 755 /755 && touch /755/755.txt
+RUN mkdir -m 777 /777 && touch /777/777.txt
 FROM centos:7
 COPY --from=base /a/blah/* /blah/
+RUN rm -fr /711 /755 /777
+COPY --from=0 /711 /711
+COPY --from=0 /755 /755
+COPY --from=0 /777 /777
+RUN mkdir /precreated /precreated/711 /precreated/755 /precreated/777
+COPY --from=0 /711 /precreated/711
+COPY --from=0 /755 /precreated/755
+COPY --from=0 /777 /precreated/777

--- a/internals.go
+++ b/internals.go
@@ -52,7 +52,7 @@ func hasSlash(input string) bool {
 
 // makeAbsolute ensures that the provided path is absolute.
 func makeAbsolute(dest, workingDir string) string {
-	// Twiddle the destination when its a relative path - meaning, make it
+	// Twiddle the destination when it's a relative path - meaning, make it
 	// relative to the WORKINGDIR
 	if dest == "." {
 		if !hasSlash(workingDir) {


### PR DESCRIPTION
Copying a directory from another stage shouldn't preserve the permissions of the directory itself, to be compatible with the behavior we see in `docker build`.