### PR TITLE
conformance: test non-root USER before WORKDIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.16"
   - "1.17"
+  - "1.18"
 
 install:
 

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -458,6 +458,16 @@ func TestConformanceInternal(t *testing.T) {
 			ContextDir: "testdata/multistage",
 			Dockerfile: "Dockerfile.env",
 		},
+		{
+			Name:       "nonroot-USER-before-WORKDIR-used",
+			ContextDir: "testdata/user-workdir",
+			Dockerfile: "Dockerfile.used",
+		},
+		{
+			Name:       "nonroot-USER-before-WORKDIR-notused",
+			ContextDir: "testdata/user-workdir",
+			Dockerfile: "Dockerfile.notused",
+		},
 	}
 
 	for i, test := range testCases {

--- a/dockerclient/testdata/user-workdir/Dockerfile.notused
+++ b/dockerclient/testdata/user-workdir/Dockerfile.notused
@@ -1,0 +1,4 @@
+FROM alpine
+RUN adduser -D buildtest
+USER buildtest
+WORKDIR /workdir/created/deep/below

--- a/dockerclient/testdata/user-workdir/Dockerfile.used
+++ b/dockerclient/testdata/user-workdir/Dockerfile.used
@@ -1,0 +1,5 @@
+FROM alpine
+RUN adduser -D buildtest
+USER buildtest
+WORKDIR /workdir/created/deep/below
+RUN ls -l /workdir


### PR DESCRIPTION
Add a test that checks who owns a WORKDIR if it's created after USER sets a non-root default runtime user.  Try to run conformance tests in CI.