### PR TITLE
dispatcher: honor default builtin-args while processing `FROM --platform=`

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -234,7 +234,9 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 			return fmt.Errorf("Windows does not support FROM scratch")
 		}
 	}
+	defaultArgs := envMapAsSlice(builtinBuildArgs)
 	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	userArgs = mergeEnv(defaultArgs, userArgs)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -683,3 +683,26 @@ func TestDispatchFromFlags(t *testing.T) {
 		t.Errorf("Expected %v, to match %v\n", expectedPlatform, mybuilder.Platform)
 	}
 }
+
+func TestDispatchFromFlagsAndUseBuiltInArgs(t *testing.T) {
+	expectedPlatform := localspec.OS + "/" + localspec.Architecture
+	mybuilder := Builder{
+		RunConfig: docker.Config{
+			WorkingDir: "/root",
+			Cmd:        []string{"/bin/sh"},
+			Image:      "busybox",
+		},
+	}
+
+	flags := []string{"--platform=$BUILDPLATFORM"}
+	args := []string{""}
+	original := "FROM --platform=$BUILDPLATFORM busybox"
+
+	if err := from(&mybuilder, args, nil, flags, original); err != nil {
+		t.Errorf("dispatchAdd error: %v", err)
+	}
+
+	if mybuilder.Platform != expectedPlatform {
+		t.Errorf("Expected %v, to match %v\n", expectedPlatform, mybuilder.Platform)
+	}
+}


### PR DESCRIPTION
While processing inline `--platform=` in `FROM` , imagebuilder ignores
default builtinArgs so for example if user wants to use inbuilt default arg
`FROM --platform=$BUILDPLATFORM` it should automatically replace it with
default value of BUILDPLATFORM.

Fixes
```Dockerfile
FROM --platform=$BUILDPLATFORM busybox
RUN echo "do something"
```