### PR TITLE
healthcheck: set appropriate defaults for `interval`, `timeout` and `retries`

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -631,6 +631,21 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
+			Dockerfile: "dockerclient/testdata/Dockerfile.healthcheckdefaults",
+			From:       "debian",
+			Config: docker.Config{
+				Image: "debian",
+				Cmd:   []string{"/bin/sh", "-c", "/app/main.sh"},
+				Healthcheck: &docker.HealthConfig{
+					StartPeriod: 0 * time.Second,
+					Interval:    30 * time.Second,
+					Timeout:     30 * time.Second,
+					Retries:     3,
+					Test:        []string{"CMD-SHELL", "/app/check.sh --quiet"},
+				},
+			},
+		},
+		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.envsubst",
 			From:       "busybox",
 			Image: &docker.Image{

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -516,12 +516,12 @@ func healthcheck(b *Builder, args []string, attributes map[string]bool, flagArgs
 		}
 
 		healthcheck := docker.HealthConfig{}
-
+		// Use docker defaults for flags https://docs.docker.com/engine/reference/builder/#healthcheck
 		flags := flag.NewFlagSet("", flag.ContinueOnError)
 		flags.String("start-period", "", "")
-		flags.String("interval", "", "")
-		flags.String("timeout", "", "")
-		flRetries := flags.String("retries", "", "")
+		flags.String("interval", "30s", "")
+		flags.String("timeout", "30s", "")
+		flRetries := flags.String("retries", "3", "")
 
 		if err := flags.Parse(flagArgs); err != nil {
 			return err

--- a/dockerclient/testdata/Dockerfile.healthcheckdefaults
+++ b/dockerclient/testdata/Dockerfile.healthcheckdefaults
@@ -1,0 +1,6 @@
+FROM debian
+CMD /app/main.sh
+HEALTHCHECK   CMD   a b
+HEALTHCHECK CMD ["foo"]
+HEALTHCHECK CMD /app/check.sh --quiet
+


### PR DESCRIPTION
Set appropriate defaults for `--interval`, `--timeout` and `--retries` when
processing a Containerfile with build format as docker.

See: https://docs.docker.com/engine/reference/builder/#healthcheck
Closes: https://github.com/containers/podman/issues/13912