### PR TITLE
Add option `--keep-ownership` to ADD/COPY

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -31,6 +31,9 @@ type Copy struct {
 	// to the executor for handling.
 	Chown string
 	Chmod string
+	// If used `--keep-ownership` on ADD/COPY (only for local files) but without 
+	// Chown option. This value is passed to the executor for handling.
+	PreserveOwnership bool
 }
 
 // Run defines a run operation required in the container.

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -140,6 +140,7 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	}
 	var chown string
 	var chmod string
+	var preserveOwnership bool
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
 	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
@@ -149,6 +150,8 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 			return err
 		}
 		switch {
+		case arg == "--keep-ownership":
+			preserveOwnership = true
 		case strings.HasPrefix(arg, "--chown="):
 			chown = strings.TrimPrefix(arg, "--chown=")
 		case strings.HasPrefix(arg, "--chmod="):
@@ -158,10 +161,15 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 				return err
 			}
 		default:
-			return fmt.Errorf("ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flag")
+			return fmt.Errorf("ADD only supports the --chmod=<permissions>, --chown=<uid:gid>, and the --keep-ownership flag")
 		}
 	}
-	b.PendingCopies = append(b.PendingCopies, Copy{Src: args[0:last], Dest: dest, Download: true, Chown: chown, Chmod: chmod})
+
+	if chown != "" && preserveOwnership {
+		return errConflictChownKeepOwnerShip("ADD")
+	}
+
+	b.PendingCopies = append(b.PendingCopies, Copy{Src: args[0:last], Dest: dest, Download: true, Chown: chown, Chmod: chmod, PreserveOwnership: preserveOwnership})
 	return nil
 }
 
@@ -177,6 +185,7 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
 	var chown string
 	var chmod string
+	var preserveOwnership bool
 	var from string
 	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
 	for _, a := range flagArgs {
@@ -185,6 +194,8 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 			return err
 		}
 		switch {
+		case arg == "--keep-ownership":
+			preserveOwnership = true
 		case strings.HasPrefix(arg, "--chown="):
 			chown = strings.TrimPrefix(arg, "--chown=")
 		case strings.HasPrefix(arg, "--chmod="):
@@ -196,10 +207,15 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 		case strings.HasPrefix(arg, "--from="):
 			from = strings.TrimPrefix(arg, "--from=")
 		default:
-			return fmt.Errorf("COPY only supports the --chmod=<permissions> --chown=<uid:gid> and the --from=<image|stage> flags")
+			return fmt.Errorf("COPY only supports the --chmod=<permissions>, --chown=<uid:gid>, --from=<image|stage>, and the --keep-ownership flags")
 		}
 	}
-	b.PendingCopies = append(b.PendingCopies, Copy{From: from, Src: args[0:last], Dest: dest, Download: false, Chown: chown, Chmod: chmod})
+
+	if chown != "" && preserveOwnership {
+		return errConflictChownKeepOwnerShip("COPY")
+	}
+
+	b.PendingCopies = append(b.PendingCopies, Copy{From: from, Src: args[0:last], Dest: dest, Download: false, Chown: chown, Chmod: chmod, PreserveOwnership: preserveOwnership})
 	return nil
 }
 
@@ -677,6 +693,10 @@ func checkChmodConversion(chmod string) error {
 		return fmt.Errorf("Error parsing chmod %s", chmod)
 	}
 	return nil
+}
+
+func errConflictChownKeepOwnerShip(command string) error {
+	return fmt.Errorf("%s only supports the --chown=<uid:gid> or --keep-ownership flag at the same time", command)
 }
 
 func errAtLeastOneArgument(command string) error {


### PR DESCRIPTION
This PR is to keep the ownership of local files, when used with ADD or COPY - BUT WITHOUT `--chown` flag

fixes #226 , Ref: https://github.com/containers/buildah/pull/3767,  containers/buildah/pull/4001

What are the the intention for the PR:

ADD or COPY 
- without `--chown` and `--keep-ownership` result in `root:root` for the files.
- with `--chown 123:456` result in `123:456` for the files.
- with `--keep-ownership` result in `UID:GID` for the files, same as the origin source.
