### PR TITLE
dispatcher: consider `builtinargs` and `userargs` while processing `baseImage` name

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -223,8 +223,12 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 	for n, v := range b.HeadingArgs {
 		argStrs = append(argStrs, n+"="+v)
 	}
+	defaultArgs := envMapAsSlice(builtinBuildArgs)
+	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	userArgs = mergeEnv(defaultArgs, userArgs)
+	nameArgs := mergeEnv(argStrs, userArgs)
 	var err error
-	if name, err = ProcessWord(name, argStrs); err != nil {
+	if name, err = ProcessWord(name, nameArgs); err != nil {
 		return err
 	}
 
@@ -234,9 +238,6 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 			return fmt.Errorf("Windows does not support FROM scratch")
 		}
 	}
-	defaultArgs := envMapAsSlice(builtinBuildArgs)
-	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
-	userArgs = mergeEnv(defaultArgs, userArgs)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {


### PR DESCRIPTION
We already consider `builtinargs` and `userArgs` while computing `--from=`
flags so use same logic for computing name of baseImage while evaluating
`FROM` statements.

Allows use cases like
```Dockerfile
FROM --platform=linux/amd64 alpine as platform-amd64
# do something

FROM --platform=linux/arm64 alpine as platform-arm64
# do something

FROM platform-${TARGETARCH}
```

also allows `FROM ${SOME_DEFAULT_OR_USER_ARG}` in general.

Closes: https://github.com/containers/podman/issues/14375