### PR TITLE
dispatcher, builder: filter `args` against `allowedArgs` while processing `FROM`, `ADD` and `RUN`

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -224,7 +224,15 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 		argStrs = append(argStrs, n+"="+v)
 	}
 	defaultArgs := envMapAsSlice(builtinBuildArgs)
-	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	filteredUserArgs := make(map[string]string)
+	for k, v := range b.UserArgs {
+		for _, a := range b.GlobalAllowedArgs {
+			if a == k {
+				filteredUserArgs[k] = v
+			}
+		}
+	}
+	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
 	userArgs = mergeEnv(defaultArgs, userArgs)
 	nameArgs := mergeEnv(argStrs, userArgs)
 	var err error

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -142,7 +142,13 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	var chmod string
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
-	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	filteredUserArgs := make(map[string]string)
+	for k, v := range b.Args {
+		if _, ok := b.AllowedArgs[k]; ok {
+			filteredUserArgs[k] = v
+		}
+	}
+	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
@@ -332,7 +338,13 @@ func run(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	args = handleJSONArgs(args, attributes)
 
 	var mounts []string
-	userArgs := mergeEnv(envMapAsSlice(b.Args), b.Env)
+	filteredUserArgs := make(map[string]string)
+	for k, v := range b.Args {
+		if _, ok := b.AllowedArgs[k]; ok {
+			filteredUserArgs[k] = v
+		}
+	}
+	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {


### PR DESCRIPTION
Following PR adds two commits to make sure we expand variables while processing `FROM`, `ADD` and `RUN` only if they are declared. See individual commits for detail.

* FROM: only resolve arg in `FROM` if declared anywhere
     Resolution of `FROM ${SOMEARG}` should happen only if `SOMEARG` was
     declared in the Containerfile.
     
 * dispatcher: filter args against allowed args while processing flags for `ADD` and `RUN`
 
 Closes: https://github.com/openshift/imagebuilder/issues/231
     
