### PR TITLE
dockerclient: fix COPYing an archive to a new location

### DIFF
--- a/dockerclient/archive.go
+++ b/dockerclient/archive.go
@@ -185,7 +185,7 @@ func archiveFromDisk(directory string, src, dst string, allowDownload bool, excl
 		directory = filepath.Dir(directory)
 	}
 
-	options, err := archiveOptionsFor(directory, infos, dst, excludes, check)
+	options, err := archiveOptionsFor(directory, infos, dst, excludes, allowDownload, check)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -635,7 +635,7 @@ func (m *archiveMapper) Filter(h *tar.Header, r io.Reader) ([]byte, bool, bool, 
 	return nil, false, false, nil
 }
 
-func archiveOptionsFor(directory string, infos []CopyInfo, dst string, excludes []string, check DirectoryCheck) (*archive.TarOptions, error) {
+func archiveOptionsFor(directory string, infos []CopyInfo, dst string, excludes []string, allowDownload bool, check DirectoryCheck) (*archive.TarOptions, error) {
 	dst = trimLeadingPath(dst)
 	dstIsDir := strings.HasSuffix(dst, "/") || dst == "." || dst == "/" || strings.HasSuffix(dst, "/.")
 	dst = trimTrailingSlash(dst)
@@ -667,7 +667,7 @@ func archiveOptionsFor(directory string, infos []CopyInfo, dst string, excludes 
 			if directory != "" {
 				infoPath = filepath.Join(directory, infoPath)
 			}
-			if isArchivePath(infoPath) {
+			if allowDownload && isArchivePath(infoPath) {
 				dstIsDir = true
 				break
 			}

--- a/dockerclient/copyinfo.go
+++ b/dockerclient/copyinfo.go
@@ -15,7 +15,7 @@ import (
 type CopyInfo struct {
 	os.FileInfo
 	Path       string
-	Decompress bool
+	Decompress bool // deprecated, is never set and is ignored
 	FromDir    bool
 }
 

--- a/dockerclient/copyinfo_test.go
+++ b/dockerclient/copyinfo_test.go
@@ -18,6 +18,7 @@ func TestCalcCopyInfo(t *testing.T) {
 		excludes       []string
 		rebaseNames    map[string]string
 		check          map[string]bool
+		download       bool
 	}{
 		{
 			origPath:       "subdir/*",
@@ -253,7 +254,7 @@ func TestCalcCopyInfo(t *testing.T) {
 				t.Errorf("did not see paths: %#v", expect)
 			}
 
-			options, err := archiveOptionsFor("", infos, test.dstPath, test.excludes, testDirectoryCheck(test.check))
+			options, err := archiveOptionsFor("", infos, test.dstPath, test.excludes, test.download, testDirectoryCheck(test.check))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/dockerclient/testdata/add/Dockerfile
+++ b/dockerclient/testdata/add/Dockerfile
@@ -1,9 +1,14 @@
 FROM centos:7
+ADD archived.txt /archived.txt
 ADD archived.txt /archived/
+ADD archived.tar /archived.tar
 ADD archived.tar /archived-tar/
+ADD archived.tar.gz /archived.tar.gz
 ADD archived.tar.gz /archived-gz/
+ADD archived.tar.bz2 /archived.tar.bz2
 ADD archived.tar.bz2 /archived-bz2/
 ADD archived.tar.xz /archived-xz/
+ADD archived.tar.xz /archived.tar.xz
 ADD archived.txt archived.tar.xz archived.tar.bz2 /archived-mixed/
 ADD archived.txt /archived.tar.xz ./archived.tar.bz2 /archived-mixed-path-variations/
 ADD archived.txt*     /archived-globbed-plain/

--- a/dockerclient/testdata/add/Dockerfile.copy
+++ b/dockerclient/testdata/add/Dockerfile.copy
@@ -1,8 +1,13 @@
 FROM centos:7
 COPY archived.txt /archived/
+COPY archived.txt /archived.txt
 COPY archived.tar /archived-tar/
+COPY archived.tar /archived.tar
 COPY archived.tar.gz /archived-gz/
+COPY archived.tar.gz /archived.tar.gz
 COPY archived.tar.bz2 /archived-bz2/
+COPY archived.tar.bz2 /archived.tar.bz2
 COPY archived.tar.xz /archived-xz/
+COPY archived.tar.xz /archived.tar.xz
 COPY archived.txt archived.tar.xz archived.tar.bz2 /archived-mixed/
 COPY archived.txt /archived.tar.xz ./archived.tar.bz2 /archived-mixed-path-variations/


### PR DESCRIPTION
When COPYing an archive to a location which doesn't exist, don't force the destination to be treated as a directory that we might have to create.  We have to do that for ADD in order to be able to extract the archive's contents, but not for COPY.

Document that the `Decompress` field from `dockerclient.CopyInfo` is both never set and ignored.

Should fix #230.