### PR TITLE
Use containers/storage/pkg/regexp to better handle init regex

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -20,12 +19,13 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 
 	"github.com/containerd/containerd/platforms"
+	"github.com/containers/storage/pkg/regexp"
 	"github.com/openshift/imagebuilder/signal"
 	"github.com/openshift/imagebuilder/strslice"
 )
 
 var (
-	obRgex = regexp.MustCompile(`(?i)^\s*ONBUILD\s*`)
+	obRgex = regexp.Delayed(`(?i)^\s*ONBUILD\s*`)
 )
 
 var localspec = platforms.DefaultSpec()

--- a/dockerfile/parser/parser.go
+++ b/dockerfile/parser/parser.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"unicode"
 
+	sRegexp "github.com/containers/storage/pkg/regexp"
 	"github.com/containers/storage/pkg/system"
 	"github.com/openshift/imagebuilder/dockerfile/command"
 	"github.com/pkg/errors"
@@ -81,10 +82,10 @@ func (node *Node) AddChild(child *Node, startLine, endLine int) {
 
 var (
 	dispatch             map[string]func(string, *Directive) (*Node, map[string]bool, error)
-	tokenWhitespace      = regexp.MustCompile(`[\t\v\f\r ]+`)
-	tokenEscapeCommand   = regexp.MustCompile(`^#[ \t]*escape[ \t]*=[ \t]*(?P<escapechar>.).*$`)
-	tokenPlatformCommand = regexp.MustCompile(`^#[ \t]*platform[ \t]*=[ \t]*(?P<platform>.*)$`)
-	tokenComment         = regexp.MustCompile(`^#.*$`)
+	tokenWhitespace      = sRegexp.Delayed(`[\t\v\f\r ]+`)
+	tokenEscapeCommand   = sRegexp.Delayed(`^#[ \t]*escape[ \t]*=[ \t]*(?P<escapechar>.).*$`)
+	tokenPlatformCommand = sRegexp.Delayed(`^#[ \t]*platform[ \t]*=[ \t]*(?P<platform>.*)$`)
+	tokenComment         = sRegexp.Delayed(`^#.*$`)
 )
 
 // DefaultEscapeToken is the default escape token

--- a/imageprogress/progress.go
+++ b/imageprogress/progress.go
@@ -6,10 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/containers/storage/pkg/regexp"
 )
 
 const (
@@ -270,7 +271,7 @@ func (w *imageProgressWriter) isStableLayerCount() bool {
 	return w.stableLines >= w.stableThreshhold
 }
 
-var layerIDRegexp = regexp.MustCompile("^[a-f0-9]*$")
+var layerIDRegexp = regexp.Delayed("^[a-f0-9]*$")
 
 func islayerStatus(line *progressLine) bool {
 	// ignore status lines with no layer id


### PR DESCRIPTION
Use github.com/containers/storage/pkg/regexp to better handle init regex
    
    The new Reexp structure, will handle the initialization of regexp
    and then will do the MustCompile within a sync.Once field.
    
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

