### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/dockerfile/parser/parser.go
+++ b/dockerfile/parser/parser.go
@@ -4,6 +4,7 @@ package parser
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/containers/storage/pkg/system"
 	"github.com/openshift/imagebuilder/dockerfile/command"
-	"github.com/pkg/errors"
 )
 
 // Node is a structure used to represent a parse tree.

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,6 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v23.0.0+incompatible
 	github.com/fsouza/go-dockerclient v1.9.4
-	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	k8s.io/klog v1.0.0
 )
@@ -35,7 +33,9 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/opencontainers/runc v1.1.4 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	golang.org/x/mod v0.8.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -151,16 +151,12 @@ golang.org/x/mod/semver
 # golang.org/x/net v0.5.0
 ## explicit; go 1.17
 golang.org/x/net/context
-# golang.org/x/sync v0.1.0
-## explicit
 # golang.org/x/sys v0.5.0
 ## explicit; go 1.17
 golang.org/x/sys/execabs
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 golang.org/x/sys/windows
-# golang.org/x/text v0.6.0
-## explicit; go 1.17
 # golang.org/x/tools v0.1.12
 ## explicit; go 1.18
 golang.org/x/tools/cmd/stringer


### PR DESCRIPTION
The package `github.com/pkg/errors` is deprecated and we can use golang native error wrapping instead.
