### PR TITLE
dispatcher,env: must honor heading `ARG` before `FROM`

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -589,7 +589,7 @@ func TestBuilder(t *testing.T) {
 			Dockerfile: "dockerclient/testdata/Dockerfile.env",
 			From:       "busybox",
 			Config: docker.Config{
-				Env:   []string{"name=value", "name2=value2a            value2b", "name1=value1", "name3=value3a\\n\"value3b\"", "name4=value4a\\nvalue4b"},
+				Env:   []string{"HELLO=world", "name=value", "name2=value2a            value2b", "name1=value1", "name3=value3a\\n\"value3b\"", "name4=value4a\\nvalue4b"},
 				Image: "busybox",
 			},
 		},

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -80,6 +80,12 @@ func env(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 		fmt.Printf("Str1:%v\n", flStr1)
 	*/
 
+	// Support ARG before from and ENV must honor that
+	headingArgs := []string{}
+	for n, v := range b.HeadingArgs {
+		headingArgs = append(headingArgs, n+"="+v)
+	}
+
 	for j := 0; j < len(args); j++ {
 		// name  ==> args[j]
 		// value ==> args[j+1]
@@ -88,6 +94,8 @@ func env(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 		b.Env = mergeEnv(b.Env, newVar)
 		j++
 	}
+	b.RunConfig.Env = mergeEnv(b.RunConfig.Env, headingArgs)
+	b.Env = mergeEnv(b.Env, headingArgs)
 
 	return nil
 }

--- a/dockerclient/testdata/Dockerfile.env
+++ b/dockerclient/testdata/Dockerfile.env
@@ -1,4 +1,6 @@
+ARG HELLO=world
 FROM busybox
+ENV HELLO=${HELLO:-earth}
 ENV name value
 ENV name=value
 ENV name=value name2=value2


### PR DESCRIPTION
Correctly process any `ARG` if declared before assigning value to any `ENV`. This is important for use cases where `ARG` is configured and passed from the user.

Use case.

```Dockerfile
ARG CONT_IMG_VER
FROM ubuntu
ENV CONT_IMG_VER=${CONT_IMG_VER:-v1.0.0}
RUN echo $CONT_IMG_VER
```

```console
buildah build --build-arg CONT_IMG_VER=xyz -t test .
```

Closes: https://github.com/containers/buildah/issues/4547
