### PR TITLE
env,unset: support syntax `${VAR_NAME:?}` to error on unset vars

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -700,6 +700,23 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
+			Dockerfile: "dockerclient/testdata/Dockerfile.unset",
+			From:       "busybox",
+			Image: &docker.Image{
+				ID: "busybox2",
+				Config: &docker.Config{
+					Env: []string{},
+				},
+			},
+			RunErrFn: func(err error) bool {
+				return err != nil && strings.Contains(err.Error(), "is not allowed to be unset")
+			},
+			Config: docker.Config{
+				Env:    []string{},
+				Labels: map[string]string{"test": ""},
+			},
+		},
+		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.args",
 			Args:       map[string]string{"BAR": "first"},
 			From:       "busybox",

--- a/dockerclient/testdata/Dockerfile.unset
+++ b/dockerclient/testdata/Dockerfile.unset
@@ -1,0 +1,5 @@
+FROM busybox
+
+ARG FOO
+ENV FOO=${FOO:?}
+LABEL test="$FOO"

--- a/shell_parser.go
+++ b/shell_parser.go
@@ -269,7 +269,14 @@ func (sw *shellWord) processDollar() (string, error) {
 					newValue = word
 				}
 				return newValue, nil
-
+			case '?':
+				if newValue == "" {
+					newValue = word
+				}
+				if newValue == "" {
+					return "", fmt.Errorf("Failed to process `%s`: %s is not allowed to be unset", sw.word, name)
+				}
+				return newValue, nil
 			default:
 				return "", fmt.Errorf("Unsupported modifier (%c) in substitution: %s", modifier, sw.word)
 			}


### PR DESCRIPTION
Docker supports ${SOME_VAR:?} syntax, which will give an error at build if SOME_VAR is unset.

```dockerfile
FROM alpine

ARG USERID

USER ${USERID:?}
```

```console
Failed to process `${USERID:?}`: USERID is not allowed to be
unset
```

Closes: https://github.com/containers/buildah/issues/4284

Ref: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02