### PR TITLE
system: use `containers/storage` for `LCOW` validation

### DIFF
--- a/dockerfile/parser/parser.go
+++ b/dockerfile/parser/parser.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/docker/docker/pkg/system"
 	"github.com/openshift/imagebuilder/dockerfile/command"
+	"github.com/containers/storage/pkg/system"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
Newer versions of `github.com/docker/docker` does not supports the LCOW validation functions which imagebuilder uses hence move them to a local package of imagebuilder and drop dependency on
`github.com/docker/docker/pkg/system`

Alternative solution: refactor imagebuilder to stop using `LCOWSupported()`

Closes and helps in: https://github.com/containers/buildah/pull/4555