### PR TITLE
builder,dispatcher: support inline `--network` in RUN statements

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -39,6 +39,8 @@ type Run struct {
 	Args  []string
 	// Mounts are mounts specified through the --mount flag inside the Containerfile
 	Mounts []string
+	// Network specifies the network mode to run the container with
+	Network string
 }
 
 type Executor interface {

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -330,6 +330,7 @@ func run(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	args = handleJSONArgs(args, attributes)
 
 	var mounts []string
+	var network string
 	filteredUserArgs := make(map[string]string)
 	for k, v := range b.Args {
 		if _, ok := b.AllowedArgs[k]; ok {
@@ -346,14 +347,17 @@ func run(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 		case strings.HasPrefix(arg, "--mount="):
 			mount := strings.TrimPrefix(arg, "--mount=")
 			mounts = append(mounts, mount)
+		case strings.HasPrefix(arg, "--network="):
+			network = strings.TrimPrefix(arg, "--network=")
 		default:
-			return fmt.Errorf("RUN only supports the --mount flag")
+			return fmt.Errorf("RUN only supports the --mount and --network flag")
 		}
 	}
 
 	run := Run{
-		Args:   args,
-		Mounts: mounts,
+		Args:    args,
+		Mounts:  mounts,
+		Network: network,
 	}
 
 	if !attributes["json"] {

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -667,6 +667,35 @@ func TestDispatchRunFlags(t *testing.T) {
 
 }
 
+func TestDispatchNetworkFlags(t *testing.T) {
+	mybuilder := Builder{
+		RunConfig: docker.Config{
+			WorkingDir: "/root",
+			Cmd:        []string{"/bin/sh"},
+			Image:      "busybox",
+		},
+	}
+
+	flags := []string{"--network=none"}
+	args := []string{"echo \"stuff\""}
+	original := "RUN --network=none echo \"stuff\""
+
+	if err := run(&mybuilder, args, nil, flags, original); err != nil {
+		t.Errorf("dispatchAdd error: %v", err)
+	}
+	expectedPendingRuns := []Run{
+		{
+			Shell:  true,
+			Args:   args,
+			Network: "none",
+		},
+	}
+
+	if !reflect.DeepEqual(mybuilder.PendingRuns, expectedPendingRuns) {
+		t.Errorf("Expected %v, to match %v\n", expectedPendingRuns, mybuilder.PendingRuns)
+	}
+}
+
 func TestDispatchRunFlagsWithArgs(t *testing.T) {
 	argsMap := make(map[string]string)
 	allowedArgs := make(map[string]bool)

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -780,6 +780,9 @@ func (e *ClientExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 	if len(run.Mounts) > 0 {
 		return fmt.Errorf("RUN --mount not supported")
 	}
+	if run.Network != "" {
+		return fmt.Errorf("RUN --network not supported")
+	}
 
 	args := make([]string, len(run.Args))
 	copy(args, run.Args)


### PR DESCRIPTION
Imagebuilder should allow clients to support inline --network in RUN stmts so users can create isolate or expose a particular build containers. 

```Dockerfile
FROM alpine
RUN --network=host wget google.com
RUN --network=none wget google.com
```
