### PR TITLE
dockerclient: don't quietly ignore --mount

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -777,6 +777,10 @@ func (e *ClientExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error 
 // the user command into a shell and perform those operations before. Since RUN
 // requires /bin/sh, we can use both 'cd' and 'export'.
 func (e *ClientExecutor) Run(run imagebuilder.Run, config docker.Config) error {
+	if len(run.Mounts) > 0 {
+		return fmt.Errorf("RUN --mount not supported")
+	}
+
 	args := make([]string, len(run.Args))
 	copy(args, run.Args)
 


### PR DESCRIPTION
The dockerclient implementation doesn't support --mount.  Instead of quietly ignoring such a flag and hoping for the best (creating issues like #187), error out.