### PR TITLE
builder,volume: `Add` must return true if path pre-exists in set

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -128,7 +128,13 @@ func (s *VolumeSet) Add(path string) bool {
 	path = strings.TrimSuffix(path, "/")
 	var adjusted []string
 	for _, p := range *s {
-		if p == path || strings.HasPrefix(path, p+"/") {
+		if p == path {
+			// if path is already in the set
+			// pretend it's added and return
+			// true
+			return true
+		}
+		if strings.HasPrefix(path, p+"/") {
 			return false
 		}
 		if strings.HasPrefix(p, path+"/") {

--- a/builder_test.go
+++ b/builder_test.go
@@ -28,8 +28,8 @@ func TestVolumeSet(t *testing.T) {
 		uncovered []string
 	}{
 		{
-			inputs:  []string{"/var/lib", "/var"},
-			changed: []bool{true, true},
+			inputs:  []string{"/var/lib", "/var", "/var"},
+			changed: []bool{true, true, true},
 			result:  []string{"/var"},
 
 			covered:   []string{"/var/lib", "/var/", "/var"},

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -396,6 +396,10 @@ func TestConformanceInternal(t *testing.T) {
 			Dockerfile: "testdata/Dockerfile.shell",
 		},
 		{
+			Name:       "preparepathwithoutrun",
+			Dockerfile: "testdata/Dockerfile.preparewithoutrun",
+		},
+		{
 			Name:       "args",
 			Dockerfile: "testdata/Dockerfile.args",
 			Args:       map[string]string{"BAR": "first"},

--- a/dockerclient/testdata/Dockerfile.preparewithoutrun
+++ b/dockerclient/testdata/Dockerfile.preparewithoutrun
@@ -1,0 +1,5 @@
+FROM busybox
+VOLUME "/hello"
+# This grep will fail if hello path does not persists
+RUN ls -a | grep hello
+LABEL ho hey


### PR DESCRIPTION
`func (s *VolumeSet) Add(path string) bool` must return `true` if its trying to add a path which already exists in the volume set.

When builder actually process volume it can add path to volume set but will not Preserve the path till a run is found.

Makes cases like this functional
```Dockerfile
FROM scratch
WORKDIR /bin

COPY hello /bin

ENTRYPOINT [ "hello" ]

VOLUME "/dev/urandom:/dev/urandom:--:iodev"

LABEL com.abc.product.rtp.rtpStackSize 0x1000000
LABEL com.abc.product.rtp.rtpPriority 50
LABEL com.abc.product.rtp.rtpOptions 0x80
LABEL com.abc.product.rtp.rtpTasksOptions 0x00
```

Where the output must contain volume `/dev`

Closes: https://github.com/containers/buildah/issues/4594