### PR TITLE
RUN-1833: dockerclient: use /bin/sleep for idling instead of sleep

### DIFF
--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -348,7 +348,7 @@ func (e *ClientExecutor) Prepare(b *imagebuilder.Builder, node *parser.Node, fro
 				opts.Config.Entrypoint = nil
 			} else {
 				// TODO; replace me with a better default command
-				opts.Config.Cmd = []string{fmt.Sprintf("%s\nsleep 86400", "#(imagebuilder)")}
+				opts.Config.Cmd = []string{"# (imagebuilder)\n/bin/sleep 86400"}
 				opts.Config.Entrypoint = append([]string{}, defaultShell...)
 			}
 		}


### PR DESCRIPTION
The built-in "sleep" in the latest alpine base image's shell behaves differently from the version it has to exec(), exiting when it receives a stray SIGCHLD for one of the processes we're running in an exec session, and this is causing a consistent failure in the "copy and env interaction" conformance test.
Call /bin/sleep explicitly to work around this.

Note to other maintainers: please do not /lgtm until Travis is green.