### PR TITLE
builder: support variables in stage names

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -104,6 +104,47 @@ func TestByTarget(t *testing.T) {
 	t.Logf("stages2: %#v", stages2)
 }
 
+func TestByVarTarget(t *testing.T) {
+	n, err := ParseFile("dockerclient/testdata/Dockerfile.var_target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stages, err := NewStages(n, NewBuilder(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 3 {
+		t.Fatalf("expected 3 stages, got %d", len(stages))
+	}
+	t.Logf("stages: %#v", stages)
+
+	stages1, found := stages.ByTarget("mytarget")
+	if !found {
+		t.Fatal("First target not found")
+	}
+	if len(stages1) != 1 {
+		t.Fatalf("expected 1 stages, got %d", len(stages1))
+	}
+	t.Logf("stages1: %#v", stages1)
+
+	stages2, found := stages.ByTarget("mytarget2")
+	if !found {
+		t.Fatal("Second target not found")
+	}
+	if len(stages2) != 1 {
+		t.Fatalf("expected 1 stages, got %d", len(stages2))
+	}
+	t.Logf("stages2: %#v", stages2)
+
+	stages3, found := stages.ThroughTarget("mytarget2")
+	if !found {
+		t.Fatal("stages up to stage 2 not found")
+	}
+	if len(stages3) != 3 {
+		t.Fatalf("expected 3 stages, got %d", len(stages3))
+	}
+}
+
 func TestThroughTarget(t *testing.T) {
 	n, err := ParseFile("dockerclient/testdata/Dockerfile.target")
 	if err != nil {

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -217,27 +217,10 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 		return fmt.Errorf("FROM requires either one argument, or three: FROM <source> [as <name>]")
 	}
 
-	name := args[0]
-
 	// Support ARG before from
-	argStrs := []string{}
-	for n, v := range b.HeadingArgs {
-		argStrs = append(argStrs, n+"="+v)
-	}
-	defaultArgs := envMapAsSlice(builtinBuildArgs)
-	filteredUserArgs := make(map[string]string)
-	for k, v := range b.UserArgs {
-		for _, a := range b.GlobalAllowedArgs {
-			if a == k {
-				filteredUserArgs[k] = v
-			}
-		}
-	}
-	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
-	userArgs = mergeEnv(defaultArgs, userArgs)
-	nameArgs := mergeEnv(argStrs, userArgs)
-	var err error
-	if name, err = ProcessWord(name, nameArgs); err != nil {
+	allArgs := b.allAvailableArgs()
+	name, err := ProcessWord(args[0], allArgs)
+	if err != nil {
 		return err
 	}
 
@@ -248,7 +231,7 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 		}
 	}
 	for _, a := range flagArgs {
-		arg, err := ProcessWord(a, userArgs)
+		arg, err := ProcessWord(a, allArgs)
 		if err != nil {
 			return err
 		}

--- a/dockerclient/testdata/Dockerfile.var_target
+++ b/dockerclient/testdata/Dockerfile.var_target
@@ -1,0 +1,10 @@
+ARG TARGET_NAME=mytarget
+
+FROM ubuntu:latest
+RUN touch /1
+
+FROM alpine:latest AS ${TARGET_NAME} 
+RUN touch /2
+
+FROM busybox:latest AS ${TARGET_NAME}2 
+RUN touch /3


### PR DESCRIPTION
Sometimes it can be useful to have dynamic stage names.

I'm not sure if my change to `dispatchers.go` is correct. Previously, the `flagArgs` got processed without `HeadingArgs` and I wasn't sure if this omission was on purpose or a bug. Please let me know if you want me to undo this change.
 
Closes https://github.com/containers/buildah/issues/4948