### PR TITLE
builder,dispatcher: Parse ADD --checksum

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -29,8 +29,9 @@ type Copy struct {
 	Download bool
 	// If set, the owner:group for the destination.  This value is passed
 	// to the executor for handling.
-	Chown string
-	Chmod string
+	Chown    string
+	Chmod    string
+	Checksum string
 }
 
 // Run defines a run operation required in the container.
@@ -78,7 +79,7 @@ func (logExecutor) EnsureContainerPathAs(path, user string, mode *os.FileMode) e
 
 func (logExecutor) Copy(excludes []string, copies ...Copy) error {
 	for _, c := range copies {
-		log.Printf("COPY %v -> %s (from:%s download:%t), chown: %s, chmod %s", c.Src, c.Dest, c.From, c.Download, c.Chown, c.Chmod)
+		log.Printf("COPY %v -> %s (from:%s download:%t), chown: %s, chmod %s, checksum: %s", c.Src, c.Dest, c.From, c.Download, c.Chown, c.Chmod, c.Checksum)
 	}
 	return nil
 }

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -137,6 +137,7 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 	}
 	var chown string
 	var chmod string
+	var checksum string
 	last := len(args) - 1
 	dest := makeAbsolute(args[last], b.RunConfig.WorkingDir)
 	filteredUserArgs := make(map[string]string)
@@ -160,11 +161,19 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 			if err != nil {
 				return err
 			}
+		case strings.HasPrefix(arg, "--checksum="):
+			checksum = strings.TrimPrefix(arg, "--checksum=")
 		default:
-			return fmt.Errorf("ADD only supports the --chmod=<permissions> and the --chown=<uid:gid> flag")
+			return fmt.Errorf("ADD only supports the --chmod=<permissions>, --chown=<uid:gid>, and --checksum=<checksum> flags")
 		}
 	}
-	b.PendingCopies = append(b.PendingCopies, Copy{Src: args[0:last], Dest: dest, Download: true, Chown: chown, Chmod: chmod})
+	b.PendingCopies = append(b.PendingCopies, Copy{
+		Src:      args[0:last],
+		Dest:     dest,
+		Download: true,
+		Chown:    chown,
+		Chmod:    chmod,
+		Checksum: checksum})
 	return nil
 }
 

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -876,6 +876,9 @@ func (e *ClientExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 func (e *ClientExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) error {
 	// copying content into a volume invalidates the archived state of any given directory
 	for _, copy := range copies {
+		if copy.Checksum != "" {
+			return fmt.Errorf("ADD --checksum not supported")
+		}
 		e.Volumes.Invalidate(copy.Dest)
 	}
 


### PR DESCRIPTION
Parse the new ADD --checksum flag.

See https://docs.docker.com/build/dockerfile/release-notes/#160.

This will be consumed by buildah. See containers/buildah#5135.

```Dockerfile
FROM scratch
ADD --checksum=sha256:5df80a9219a28d21f96e8c99e5406d19dbe65b9673a7724e587584b02143038c https://github.com/containers/podman/releases/download/v4.7.2/podman-remote-static-linux_amd64.tar.gz /
```