### PR TITLE
TestDispatchFromFlagsAndUseBuiltInArgs: expect variants to be used

### DIFF
--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -931,6 +931,9 @@ func TestDispatchFromFlags(t *testing.T) {
 
 func TestDispatchFromFlagsAndUseBuiltInArgs(t *testing.T) {
 	expectedPlatform := localspec.OS + "/" + localspec.Architecture
+	if localspec.Variant != "" {
+		expectedPlatform += "/" + localspec.Variant
+	}
 	mybuilder := Builder{
 		RunConfig: docker.Config{
 			WorkingDir: "/root",


### PR DESCRIPTION
If we're on a platform where the local platform spec includes a non-empty variant value, expect it to be used in tests that create a Builder for the local platform.

Should fix #263.