### PR TITLE
Stages.ByName/ByTarget/ThroughTarget: accept numbers

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -198,6 +198,21 @@ func (stages Stages) ByName(name string) (Stage, bool) {
 			return stage, true
 		}
 	}
+	if i, err := strconv.Atoi(name); err == nil {
+		return stages.ByPosition(i)
+	}
+	return Stage{}, false
+}
+
+func (stages Stages) ByPosition(position int) (Stage, bool) {
+	for _, stage := range stages {
+		// stage.Position is expected to be the same as the unnamed
+		// index variable for this loop, but comparing to the Position
+		// field's value is easier to explain
+		if stage.Position == position {
+			return stage, true
+		}
+	}
 	return Stage{}, false
 }
 
@@ -211,6 +226,16 @@ func (stages Stages) ByTarget(target string) (Stages, bool) {
 			return stages[i : i+1], true
 		}
 	}
+	if position, err := strconv.Atoi(target); err == nil {
+		for i, stage := range stages {
+			// stage.Position is expected to be the same as the unnamed
+			// index variable for this loop, but comparing to the Position
+			// field's value is easier to explain
+			if stage.Position == position {
+				return stages[i : i+1], true
+			}
+		}
+	}
 	return nil, false
 }
 
@@ -222,6 +247,16 @@ func (stages Stages) ThroughTarget(target string) (Stages, bool) {
 	for i, stage := range stages {
 		if stage.Name == target {
 			return stages[0 : i+1], true
+		}
+	}
+	if position, err := strconv.Atoi(target); err == nil {
+		for i, stage := range stages {
+			// stage.Position is expected to be the same as the unnamed
+			// index variable for this loop, but comparing to the Position
+			// field's value is easier to explain
+			if stage.Position == position {
+				return stages[0 : i+1], true
+			}
 		}
 	}
 	return nil, false

--- a/builder_test.go
+++ b/builder_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/openshift/imagebuilder/dockerfile/parser"
@@ -102,6 +103,26 @@ func TestByTarget(t *testing.T) {
 		t.Fatalf("expected 1 stages, got %d", len(stages2))
 	}
 	t.Logf("stages2: %#v", stages2)
+
+	stages3, found := stages.ByTarget("1")
+	if !found {
+		t.Fatal("Third target not found")
+	}
+	if len(stages3) != 1 {
+		t.Fatalf("expected 1 stages, got %d", len(stages3))
+	}
+	t.Logf("stages3: %#v", stages3)
+	assert.Equal(t, stages3, stages1)
+
+	stages4, found := stages.ByTarget("2")
+	if !found {
+		t.Fatal("Fourth target not found")
+	}
+	if len(stages4) != 1 {
+		t.Fatalf("expected 1 stages, got %d", len(stages4))
+	}
+	t.Logf("stages4: %#v", stages4)
+	assert.Equal(t, stages4, stages2)
 }
 
 func TestThroughTarget(t *testing.T) {
@@ -135,6 +156,26 @@ func TestThroughTarget(t *testing.T) {
 		t.Fatalf("expected 3 stages, got %d", len(stages2))
 	}
 	t.Logf("stages2: %#v", stages2)
+
+	stages3, found := stages.ThroughTarget("1")
+	if !found {
+		t.Fatal("Third target not found")
+	}
+	if len(stages3) != 2 {
+		t.Fatalf("expected 2 stages, got %d", len(stages3))
+	}
+	t.Logf("stages3: %#v", stages3)
+	assert.Equal(t, stages3, stages1)
+
+	stages4, found := stages.ThroughTarget("2")
+	if !found {
+		t.Fatal("Fourth target not found")
+	}
+	if len(stages4) != 3 {
+		t.Fatalf("expected 3 stages, got %d", len(stages4))
+	}
+	t.Logf("stages4: %#v", stages4)
+	assert.Equal(t, stages4, stages2)
 }
 
 func TestMultiStageParse(t *testing.T) {


### PR DESCRIPTION
Accept integer values in ByName(), ByTarget(), and ThroughTarget() as aliases for the stages with that "Position" value.  Add a ByPosition() alongside ByName().

It would be faster to just index the stages directly instead of searching for a stage with the right Position value, but this lets us avoid a bounds check and is just easier to explain.

Fixes #274.