### PR TITLE
Trim trailing path separators from WORKDIR values

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -372,6 +372,10 @@ func workdir(b *Builder, args []string, attributes map[string]bool, flagArgs []s
 		workdir = filepath.Join(string(os.PathSeparator), current, workdir)
 	}
 
+	if workdir != string(os.PathSeparator) {
+		workdir = strings.TrimSuffix(workdir, string(os.PathSeparator))
+	}
+
 	b.RunConfig.WorkingDir = workdir
 	return nil
 }

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -484,6 +484,14 @@ func TestConformanceInternal(t *testing.T) {
 			Name:       "healthcheck",
 			Dockerfile: "testdata/Dockerfile.healthcheck",
 		},
+		{
+			Name:       "workdir-with-trailing-path-separator",
+			Dockerfile: "testdata/workdir/Dockerfile.trailing",
+		},
+		{
+			Name:       "workdir-without-trailing-path-separator",
+			Dockerfile: "testdata/workdir/Dockerfile.notrailing",
+		},
 	}
 
 	for i, test := range testCases {
@@ -518,7 +526,7 @@ func TestConformanceExternal(t *testing.T) {
 		{
 			Name: "copy and env interaction",
 			// Tests COPY and other complex interactions of ENV
-			ContextDir: "16/alpine3.18",
+			ContextDir: "16/alpine3.20",
 			Dockerfile: "Dockerfile",
 			Git:        "https://github.com/docker-library/postgres.git",
 			Ignore: []ignoreFunc{

--- a/dockerclient/testdata/workdir/Dockerfile.notrailing
+++ b/dockerclient/testdata/workdir/Dockerfile.notrailing
@@ -1,0 +1,3 @@
+FROM busybox
+USER daemon
+WORKDIR /tmp

--- a/dockerclient/testdata/workdir/Dockerfile.trailing
+++ b/dockerclient/testdata/workdir/Dockerfile.trailing
@@ -1,0 +1,3 @@
+FROM busybox
+USER daemon
+WORKDIR /tmp/


### PR DESCRIPTION
Compatibility requires that we trim trailing path separators from WORKDIR values.  This should resolve https://github.com/containers/buildah/pull/5526#issuecomment-2115408076.