### PR TITLE
dispatcher: honor heading args while processing FROM --platform

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -308,7 +308,7 @@ func from(b *Builder, args []string, attributes map[string]bool, flagArgs []stri
 		}
 	}
 	for _, a := range flagArgs {
-		arg, err := ProcessWord(a, userArgs)
+		arg, err := ProcessWord(a, nameArgs)
 		if err != nil {
 			return err
 		}

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -954,3 +954,29 @@ func TestDispatchFromFlagsAndUseBuiltInArgs(t *testing.T) {
 		t.Errorf("Expected %v, to match %v\n", expectedPlatform, mybuilder.Platform)
 	}
 }
+
+func TestDispatchFromFlagsAndUseHeadingArgs(t *testing.T) {
+	expectedPlatform := "foo/bar"
+	mybuilder := Builder{
+		HeadingArgs: map[string]string{
+			"TMP": expectedPlatform,
+		},
+		RunConfig: docker.Config{
+			WorkingDir: "/root",
+			Cmd:        []string{"/bin/sh"},
+			Image:      "busybox",
+		},
+	}
+
+	flags := []string{"--platform=$TMP"}
+	args := []string{""}
+	original := "FROM --platform=$TMP busybox"
+
+	if err := from(&mybuilder, args, nil, flags, original, nil); err != nil {
+		t.Errorf("from error: %v", err)
+	}
+
+	if mybuilder.Platform != expectedPlatform {
+		t.Errorf("Expected %v, to match %v\n", expectedPlatform, mybuilder.Platform)
+	}
+}


### PR DESCRIPTION
When evaluating flag arguments to FROM instructions (currently that's just --platform=), also consider the values of ARGs defined in the heading (the part of the file before the first FROM instruction), as we do when evaluating the name of the base image or stage.