### PR TITLE
Ignore no docker configuration found error

### DIFF
--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/docker/distribution/reference"
 	dockerregistrytypes "github.com/docker/docker/api/types/registry"
@@ -90,10 +92,14 @@ func main() {
 	options.Out, options.ErrOut = os.Stdout, os.Stderr
 	authConfigurations, err := docker.NewAuthConfigurationsFromDockerCfg()
 	if err != nil {
-		log.Fatalf("reading authentication configurations: %v", err)
+		if errors.Is(err, syscall.ENOENT) {
+			klog.Warning("No docker configuration found")
+		} else {
+			log.Fatalf("reading authentication configurations: %v", err)
+		}
 	}
 	if authConfigurations == nil {
-		klog.V(4).Infof("No authentication secrets found")
+		klog.V(4).Info("No authentication secrets found")
 	}
 
 	options.AuthFn = func(name string) ([]dockerregistrytypes.AuthConfig, bool) {


### PR DESCRIPTION
I am using podman, when I try to use the imagebuilder `--allow-pull` to pull a public image, I got:
```
╰─$ imagebuilder --allow-pull -t quay.io/open-cluster-management/registration:latest -f ./build/Dockerfile.registration .
reading authentication configurations: open /Users/jiazhu/.dockercfg: no such file or directory
```

After this fix, it will be:
```
╰─$ imagebuilder --allow-pull -t quay.io/open-cluster-management/registration:latest -f ./build/Dockerfile.registration .
W0721 11:34:02.229826   14874 imagebuilder.go:94] No docker configuration found
--> FROM golang:1.22-bullseye as builder
--> ARG OS=linux
--> ARG ARCH=amd64
```

related issue: https://github.com/openshift/imagebuilder/issues/257