### PR TITLE
Tag v1.2.14

### DIFF
--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -34,7 +34,7 @@ func main() {
 	var version bool
 	var mountSpecs stringSliceFlag
 
-	VERSION := "1.2.14-dev"
+	VERSION := "1.2.14"
 	arguments := stringMapFlag{}
 
 	flag.Var(&tags, "t", "The name to assign this image, if any. May be specified multiple times.")

--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -34,7 +34,7 @@ func main() {
 	var version bool
 	var mountSpecs stringSliceFlag
 
-	VERSION := "1.2.14"
+	VERSION := "1.2.15-dev"
 	arguments := stringMapFlag{}
 
 	flag.Var(&tags, "t", "The name to assign this image, if any. May be specified multiple times.")

--- a/imagebuilder.spec
+++ b/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.19
-%{!?version: %global version 1.2.14-dev}
+%{!?version: %global version 1.2.14}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/imagebuilder.spec
+++ b/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.19
-%{!?version: %global version 1.2.14}
+%{!?version: %global version 1.2.15-dev}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder


### PR DESCRIPTION
The merge commit for #295 included bits from #294 that we needed, so the commit that we tagged as v1.2.13 didn't include them.  I don't really understand why that happened, but integers are free, so we can tag again.