### PR TITLE
Set empty `TARGETVARIANT` and `BUILDVARIANT`

### DIFF
--- a/dispatchers.go
+++ b/dispatchers.go
@@ -41,18 +41,11 @@ var builtinArgDefaults = map[string]string{
 	"TARGETPLATFORM": localspec.OS + "/" + localspec.Architecture,
 	"TARGETOS":       localspec.OS,
 	"TARGETARCH":     localspec.Architecture,
-	"TARGETVARIANT":  localspec.Variant,
+	"TARGETVARIANT":  "",
 	"BUILDPLATFORM":  localspec.OS + "/" + localspec.Architecture,
 	"BUILDOS":        localspec.OS,
 	"BUILDARCH":      localspec.Architecture,
-	"BUILDVARIANT":   localspec.Variant,
-}
-
-func init() {
-	if localspec.Variant != "" {
-		builtinArgDefaults["TARGETPLATFORM"] = builtinArgDefaults["TARGETPLATFORM"] + "/" + localspec.Variant
-		builtinArgDefaults["BUILDPLATFORM"] = builtinArgDefaults["BUILDPLATFORM"] + "/" + localspec.Variant
-	}
+	"BUILDVARIANT":   "",
 }
 
 // ENV foo bar

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/containerd/errdefs"
@@ -44,7 +43,7 @@ func TestDispatchArgTargetPlatformGood(t *testing.T) {
 	expectedArgs := []string{
 		"TARGETARCH=286",
 		"TARGETOS=android",
-		strings.TrimSuffix("TARGETPLATFORM="+localspec.OS+"/"+localspec.Architecture+"/"+localspec.Variant, "/"),
+		"TARGETPLATFORM=" + localspec.OS + "/" + localspec.Architecture,
 		"TARGETVARIANT=with-287",
 	}
 	got := mybuilder.Arguments()
@@ -939,9 +938,6 @@ func TestDispatchFromFlags(t *testing.T) {
 
 func TestDispatchFromFlagsAndUseBuiltInArgs(t *testing.T) {
 	expectedPlatform := localspec.OS + "/" + localspec.Architecture
-	if localspec.Variant != "" {
-		expectedPlatform += "/" + localspec.Variant
-	}
 	mybuilder := Builder{
 		RunConfig: docker.Config{
 			WorkingDir: "/root",

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -499,6 +499,11 @@ func TestConformanceInternal(t *testing.T) {
 			Args:       map[string]string{"SOURCE": "source", "BUSYBOX": "busybox", "ALPINE": "alpine", "OWNERID": "0", "SECONDBASE": "localhost/no-such-image", "TARGETOS": "android", "TARGETARCH": "286", "TARGETVARIANT": "with-287"},
 		},
 		{
+			Name:       "multistage-builtin-args", // By default, BUILDVARIANT/TARGETVARIANT should be empty.
+			Version:    docker.BuilderBuildKit,
+			Dockerfile: "testdata/builtins/Dockerfile.margs",
+		},
+		{
 			Name:       "header-builtin",
 			Version:    docker.BuilderBuildKit,
 			ContextDir: "testdata/header-builtin",

--- a/dockerclient/testdata/builtins/Dockerfile.margs
+++ b/dockerclient/testdata/builtins/Dockerfile.margs
@@ -1,0 +1,39 @@
+FROM alpine
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN mkdir first
+RUN echo ${BUILDPLATFORM}  > first/buildplatform=`echo ${BUILDPLATFORM} | sed s,/,_,g`
+RUN echo ${BUILDOS}        > first/buildos=`echo ${BUILDOS} | sed s,/,_,g`
+RUN echo ${BUILDARCH}      > first/buildarch=`echo ${BUILDARCH} | sed s,/,_,g`
+RUN echo ${BUILDVARIANT}   > first/buildvariant=`echo ${BUILDVARIANT} | sed s,/,_,g`
+RUN echo ${TARGETPLATFORM} > first/targetplatform=`echo ${TARGETPLATFORM} | sed s,/,_,g`
+RUN echo ${TARGETOS}       > first/targetos=`echo ${TARGETOS} | sed s,/,_,g`
+RUN echo ${TARGETARCH}     > first/targetarch=`echo ${TARGETARCH} | sed s,/,_,g`
+RUN echo ${TARGETVARIANT}  > first/targetvariant=`echo ${TARGETVARIANT} | sed s,/,_,g`
+
+FROM alpine
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN mkdir second
+RUN echo ${BUILDPLATFORM}  > second/buildplatform=`echo ${BUILDPLATFORM} | sed s,/,_,g`
+RUN echo ${BUILDOS}        > second/buildos=`echo ${BUILDOS} | sed s,/,_,g`
+RUN echo ${BUILDARCH}      > second/buildarch=`echo ${BUILDARCH} | sed s,/,_,g`
+RUN echo ${BUILDVARIANT}   > second/buildvariant=`echo ${BUILDVARIANT} | sed s,/,_,g`
+RUN echo ${TARGETPLATFORM} > second/targetplatform=`echo ${TARGETPLATFORM} | sed s,/,_,g`
+RUN echo ${TARGETOS}       > second/targetos=`echo ${TARGETOS} | sed s,/,_,g`
+RUN echo ${TARGETARCH}     > second/targetarch=`echo ${TARGETARCH} | sed s,/,_,g`
+RUN echo ${TARGETVARIANT}  > second/targetvariant=`echo ${TARGETVARIANT} | sed s,/,_,g`
+COPY --from=0 first/* ./first/
+RUN touch -r /etc/os-release first first/* second second/*


### PR DESCRIPTION
This PR sets empty values as the default value for the `TARGETVARIANT` and `BUILDVARIANT` buildin arguments since Docker does not insert these values for `ARM64`.

Related PR:
- https://github.com/containers/buildah/pull/5990