### PR TITLE
Use non-default registries in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,14 @@ before_install:
   - sudo apt-get update -q -y
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - sudo systemctl enable --now docker.service && sudo systemctl enable --now docker.socket
-  - docker pull busybox
-  - docker pull centos:7
-  - docker pull alpine
+  - docker pull mirror.gcr.io/alpine
+  - docker pull mirror.gcr.io/busybox
+  - docker pull public.ecr.aws/docker/library/centos:7
+  - docker pull mirror.gcr.io/debian
   - docker pull registry.fedoraproject.org/fedora-minimal
   - docker pull registry.fedoraproject.org/fedora-minimal:42-x86_64
   - docker pull registry.fedoraproject.org/fedora-minimal:42-aarch64
+  - docker pull mirror.gcr.io/golang:1.24
   - chmod -R go-w ./dockerclient/testdata
 
 script:

--- a/README.md
+++ b/README.md
@@ -102,12 +102,15 @@ Example of usage from OpenShift's experimental `dockerbuild` [command with mount
 ## Run conformance tests (very slow):
 
 ```
-docker rmi busybox; docker pull busybox
-docker rmi alpine; docker pull alpine
-docker rmi centos:7; docker pull centos:7
+docker rmi mirror.gcr.io/alpine; docker pull mirror.gcr.io/alpine
+docker rmi mirror.gcr.io/busybox; docker pull mirror.gcr.io/busybox
+docker rmi public.ecr.aws/docker/library/centos:7; docker pull public.ecr.aws/docker/library/centos:7
+docker rmi mirror.gcr.io/debian; docker pull mirror.gcr.io/debian
 docker rmi registry.fedoraproject.org/fedora-minimal; docker pull registry.fedoraproject.org/fedora-minimal
 docker rmi registry.fedoraproject.org/fedora-minimal:42-x86_64; docker pull registry.fedoraproject.org/fedora-minimal:42-x86_64
 docker rmi registry.fedoraproject.org/fedora-minimal:42-aarch64; docker pull registry.fedoraproject.org/fedora-minimal:42-aarch64
+docker rmi mirror.gcr.io/golang:1.24; docker pull mirror.gcr.io/golang:1.24
+docker rmi mirror.gcr.io/nginx; docker pull mirror.gcr.io/nginx
 chmod -R go-w ./dockerclient/testdata
 go test ./dockerclient -tags conformance -timeout 30m
 ```

--- a/builder_test.go
+++ b/builder_test.go
@@ -244,7 +244,7 @@ func TestMultiStageParseHeadingArg(t *testing.T) {
 		t.Fatalf("expected 3 stages, got %d", len(stages))
 	}
 
-	fromImages := []string{"golang:1.9", "busybox:latest", "golang:1.9"}
+	fromImages := []string{"mirror.gcr.io/golang:1.24", "mirror.gcr.io/busybox:latest", "mirror.gcr.io/golang:1.24"}
 	for i, stage := range stages {
 		from, err := stage.Builder.From(stage.Node)
 		if err != nil {
@@ -603,7 +603,7 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if from != "busybox" {
+	if from != "mirror.gcr.io/busybox" {
 		t.Fatalf("unexpected from: %s", from)
 	}
 	for _, child := range node.Children {
@@ -670,37 +670,37 @@ func TestBuilder(t *testing.T) {
 	}{
 		{
 			Dockerfile: "dockerclient/testdata/dir/Dockerfile",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Copies: []Copy{
 				{Src: []string{"."}, Dest: "/", Download: false},
 				{Src: []string{"."}, Dest: "/dir"},
 				{Src: []string{"subdir/"}, Dest: "/test/", Download: false},
 			},
 			Config: docker.Config{
-				Image: "busybox",
+				Image: "mirror.gcr.io/busybox",
 			},
 		},
 		{
 			Dockerfile: "dockerclient/testdata/ignore/Dockerfile",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Copies: []Copy{
 				{Src: []string{"."}, Dest: "/"},
 			},
 			Config: docker.Config{
-				Image: "busybox",
+				Image: "mirror.gcr.io/busybox",
 			},
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.env",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Config: docker.Config{
 				Env:   []string{"name=value", "name2=value2a            value2b", "name1=value1", "name3=value3a\\n\"value3b\"", "name4=value4a\\nvalue4b"},
-				Image: "busybox",
+				Image: "mirror.gcr.io/busybox",
 			},
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.edgecases",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Copies: []Copy{
 				{Src: []string{"."}, Dest: "/", Download: true},
 				{Src: []string{"."}, Dest: "/test/copy"},
@@ -719,7 +719,7 @@ func TestBuilder(t *testing.T) {
 				ExposedPorts: map[docker.Port]struct{}{"6000/tcp": {}, "3000/tcp": {}, "9000/tcp": {}, "5000/tcp": {}},
 				Env:          []string{"SCUBA=1 DUBA 3"},
 				Cmd:          []string{"/bin/sh", "-c", "echo 'test' | wc -"},
-				Image:        "busybox",
+				Image:        "mirror.gcr.io/busybox",
 				Volumes:      map[string]struct{}{"/test2": {}, "/test3": {}, "/test": {}},
 				WorkingDir:   "/test",
 				OnBuild:      []string{"RUN [\"echo\", \"test\"]", "RUN echo test", "COPY . /"},
@@ -727,26 +727,26 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.unknown",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Unrecognized: []Step{
 				{Command: "health", Message: "HEALTH ", Original: "HEALTH NONE", Args: []string{""}, Flags: []string{}, Env: []string{}},
 				{Command: "unrecognized", Message: "UNRECOGNIZED ", Original: "UNRECOGNIZED", Args: []string{""}, Env: []string{}},
 			},
 			Config: docker.Config{
-				Image: "busybox",
+				Image: "mirror.gcr.io/busybox",
 			},
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.exposedefault",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Config: docker.Config{
 				ExposedPorts: map[docker.Port]struct{}{"3469/tcp": {}},
-				Image:        "busybox",
+				Image:        "mirror.gcr.io/busybox",
 			},
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.add",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Copies: []Copy{
 				{Src: []string{"https://github.com/openshift/origin/raw/main/README.md"}, Dest: "/README.md", Download: true},
 				{Src: []string{"https://github.com/openshift/origin/raw/main/LICENSE"}, Dest: "/", Download: true},
@@ -760,15 +760,15 @@ func TestBuilder(t *testing.T) {
 				{Shell: true, Args: []string{"mkdir ./b"}},
 			},
 			Config: docker.Config{
-				Image: "busybox",
+				Image: "mirror.gcr.io/busybox",
 				User:  "root",
 			},
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.badhealthcheck",
-			From:       "debian",
+			From:       "mirror.gcr.io/debian",
 			Config: docker.Config{
-				Image: "busybox",
+				Image: "mirror.gcr.io/busybox",
 			},
 			RunErrFn: func(err error) bool {
 				return err != nil && strings.Contains(err.Error(), "HEALTHCHECK requires at least one argument")
@@ -776,9 +776,9 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.healthcheck",
-			From:       "debian",
+			From:       "mirror.gcr.io/debian",
 			Config: docker.Config{
-				Image: "debian",
+				Image: "mirror.gcr.io/debian",
 				Cmd:   []string{"/bin/sh", "-c", "/app/main.sh"},
 				Healthcheck: &docker.HealthConfig{
 					StartPeriod:   8 * time.Second,
@@ -792,9 +792,9 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.healthcheck_defaults",
-			From:       "debian",
+			From:       "mirror.gcr.io/debian",
 			Config: docker.Config{
-				Image: "debian",
+				Image: "mirror.gcr.io/debian",
 				Cmd:   []string{"/bin/sh", "-c", "/app/main.sh"},
 				Healthcheck: &docker.HealthConfig{
 					StartPeriod:   0 * time.Second,
@@ -808,7 +808,7 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.envsubst",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Image: &docker.Image{
 				ID: "busybox2",
 				Config: &docker.Config{
@@ -822,7 +822,7 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.unset",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Image: &docker.Image{
 				ID: "busybox2",
 				Config: &docker.Config{
@@ -840,9 +840,9 @@ func TestBuilder(t *testing.T) {
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.args",
 			Args:       map[string]string{"BAR": "first"},
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Config: docker.Config{
-				Image:  "busybox",
+				Image:  "mirror.gcr.io/busybox",
 				Env:    []string{"FOO=value", "TEST=", "BAZ=first"},
 				Labels: map[string]string{"test": "value"},
 			},
@@ -852,7 +852,7 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/volume/Dockerfile",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Image: &docker.Image{
 				ID:     "busybox2",
 				Config: &docker.Config{},
@@ -872,9 +872,9 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/volumerun/Dockerfile",
-			From:       "busybox",
+			From:       "mirror.gcr.io/busybox",
 			Config: docker.Config{
-				Image: "busybox",
+				Image: "mirror.gcr.io/busybox",
 				Volumes: map[string]struct{}{
 					"/var/www": {},
 				},
@@ -892,7 +892,7 @@ func TestBuilder(t *testing.T) {
 			Dockerfile: "dockerclient/testdata/multistage/Dockerfile",
 			From:       "busybox",
 			Config: docker.Config{
-				Image:      "busybox",
+				Image:      "mirror.gcr.io/busybox",
 				WorkingDir: "/tmp",
 			},
 			FromErrFn: func(err error) bool {
@@ -909,9 +909,9 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			Dockerfile: "dockerclient/testdata/Dockerfile.shell",
-			From:       "centos:7",
+			From:       "public.ecr.aws/docker/library/centos:7",
 			Config: docker.Config{
-				Image: "centos:7",
+				Image: "public.ecr.aws/docker/library/centos:7",
 				Shell: []string{"/bin/bash", "-xc"},
 			},
 			Runs: []Run{
@@ -1048,7 +1048,7 @@ func TestRunWithMultiArg(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if from != "alpine" {
+	if from != "mirror.gcr.io/alpine" {
 		t.Fatalf("unexpected from: %s", from)
 	}
 	for _, child := range node.Children {

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -85,7 +85,7 @@ func TestMount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `91 /tmp/test/Dockerfile 644 regular file 0 0
+	expected := `105 /tmp/test/Dockerfile 644 regular file 0 0
 4 /tmp/test/file 644 regular file 0 0
 5 /tmp/test/file2 644 regular file 0 0
 `
@@ -145,9 +145,9 @@ func TestCopyFrom(t *testing.T) {
 			e.Out, e.ErrOut = out, out
 			b := imagebuilder.NewBuilder(nil)
 			dockerfile := fmt.Sprintf(`
-				FROM busybox AS base
+				FROM mirror.gcr.io/busybox AS base
 				RUN %s
-				FROM busybox
+				FROM mirror.gcr.io/busybox
 				%s
 				COPY --from=base %s
 				RUN %s
@@ -497,7 +497,7 @@ func TestConformanceInternal(t *testing.T) {
 			Name:       "builtins",
 			Version:    docker.BuilderBuildKit,
 			ContextDir: "testdata/builtins",
-			Args:       map[string]string{"SOURCE": "source", "BUSYBOX": "busybox", "ALPINE": "alpine", "OWNERID": "0", "SECONDBASE": "localhost/no-such-image", "TARGETOS": "android", "TARGETARCH": "286", "TARGETVARIANT": "with-287"},
+			Args:       map[string]string{"SOURCE": "source", "BUSYBOX": "mirror.gcr.io/busybox", "ALPINE": "mirror.gcr.io/alpine", "OWNERID": "0", "SECONDBASE": "localhost/no-such-image", "TARGETOS": "android", "TARGETARCH": "286", "TARGETVARIANT": "with-287"},
 		},
 		{
 			Name:       "multistage-builtin-args", // By default, BUILDVARIANT/TARGETVARIANT should be empty.
@@ -556,7 +556,7 @@ func TestConformanceExternal(t *testing.T) {
 		{
 			Name: "copy and env interaction",
 			// Tests COPY and other complex interactions of ENV
-			ContextDir: "16/alpine3.20",
+			ContextDir: "18/alpine3.22",
 			Dockerfile: "Dockerfile",
 			Git:        "https://github.com/docker-library/postgres.git",
 			Ignore: []ignoreFunc{
@@ -613,7 +613,7 @@ func TestTransientMount(t *testing.T) {
 	out := &bytes.Buffer{}
 	e.Out = out
 	b := imagebuilder.NewBuilder(nil)
-	node, err := imagebuilder.ParseDockerfile(bytes.NewBufferString("FROM busybox\nRUN ls /mountdir/subdir\nRUN cat /mountfile\n"))
+	node, err := imagebuilder.ParseDockerfile(bytes.NewBufferString("FROM mirror.gcr.io/busybox\nRUN ls /mountdir/subdir\nRUN cat /mountfile\n"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dockerclient/testdata/Dockerfile.add
+++ b/dockerclient/testdata/Dockerfile.add
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ADD https://github.com/openshift/origin/raw/main/README.md README.md
 USER 1001
 ADD https://github.com/openshift/origin/raw/main/LICENSE .

--- a/dockerclient/testdata/Dockerfile.args
+++ b/dockerclient/testdata/Dockerfile.args
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ENV FOO="value" TEST=$BAR
 LABEL test="$FOO"

--- a/dockerclient/testdata/Dockerfile.badhealthcheck
+++ b/dockerclient/testdata/Dockerfile.badhealthcheck
@@ -1,2 +1,2 @@
-FROM debian
+FROM mirror.gcr.io/debian
 HEALTHCHECK

--- a/dockerclient/testdata/Dockerfile.copyfrom_1
+++ b/dockerclient/testdata/Dockerfile.copyfrom_1
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch /a /b
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a /
 RUN ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_10
+++ b/dockerclient/testdata/Dockerfile.copyfrom_10
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch /a/1
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/1 /a/b/c
 RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/dockerclient/testdata/Dockerfile.copyfrom_11
+++ b/dockerclient/testdata/Dockerfile.copyfrom_11
@@ -1,6 +1,6 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch /a/1
 RUN ln -s /a /b
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /b/1 /a/b/c
 RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/dockerclient/testdata/Dockerfile.copyfrom_12
+++ b/dockerclient/testdata/Dockerfile.copyfrom_12
@@ -1,6 +1,6 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch /a/1
 RUN ln -s a /c
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /c/1 /a/b/c
 RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/dockerclient/testdata/Dockerfile.copyfrom_13
+++ b/dockerclient/testdata/Dockerfile.copyfrom_13
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch /a
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=0 /a /
 RUN ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_14
+++ b/dockerclient/testdata/Dockerfile.copyfrom_14
@@ -1,5 +1,5 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN touch /a
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=0 /a /
 RUN ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_2
+++ b/dockerclient/testdata/Dockerfile.copyfrom_2
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch /a
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a /a
 RUN ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_3
+++ b/dockerclient/testdata/Dockerfile.copyfrom_3
@@ -1,6 +1,6 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch /a
-FROM busybox
+FROM mirror.gcr.io/busybox
 WORKDIR /b
 COPY --from=base /a .
 RUN ls -al /b/a

--- a/dockerclient/testdata/Dockerfile.copyfrom_4
+++ b/dockerclient/testdata/Dockerfile.copyfrom_4
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b/ /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a

--- a/dockerclient/testdata/Dockerfile.copyfrom_5
+++ b/dockerclient/testdata/Dockerfile.copyfrom_5
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b/* /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/dockerclient/testdata/Dockerfile.copyfrom_6
+++ b/dockerclient/testdata/Dockerfile.copyfrom_6
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b/. /b/
 RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/dockerclient/testdata/Dockerfile.copyfrom_7
+++ b/dockerclient/testdata/Dockerfile.copyfrom_7
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN touch /b
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /b /a
 RUN ls -al /a && ! ls -al /b

--- a/dockerclient/testdata/Dockerfile.copyfrom_8
+++ b/dockerclient/testdata/Dockerfile.copyfrom_8
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch /a/b
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/b /a
 RUN ls -al /a && ! ls -al /b

--- a/dockerclient/testdata/Dockerfile.copyfrom_9
+++ b/dockerclient/testdata/Dockerfile.copyfrom_9
@@ -1,5 +1,5 @@
-FROM busybox as base
+FROM mirror.gcr.io/busybox as base
 RUN mkdir -p /a && touch /a/1
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=base /a/1 /a/b/c/
 RUN ls -al /a/b/c/1 && ! ls -al /a/b/1

--- a/dockerclient/testdata/Dockerfile.edgecases
+++ b/dockerclient/testdata/Dockerfile.edgecases
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 MAINTAINER docker <docker@docker.io>
 

--- a/dockerclient/testdata/Dockerfile.env
+++ b/dockerclient/testdata/Dockerfile.env
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ENV name value
 ENV name=value
 ENV name=value name2=value2

--- a/dockerclient/testdata/Dockerfile.envsubst
+++ b/dockerclient/testdata/Dockerfile.envsubst
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ENV FOO="value"
 LABEL test="$FOO"

--- a/dockerclient/testdata/Dockerfile.escape
+++ b/dockerclient/testdata/Dockerfile.escape
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN stat -c %u /

--- a/dockerclient/testdata/Dockerfile.exposedefault
+++ b/dockerclient/testdata/Dockerfile.exposedefault
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 EXPOSE 3469

--- a/dockerclient/testdata/Dockerfile.healthcheck
+++ b/dockerclient/testdata/Dockerfile.healthcheck
@@ -1,4 +1,4 @@
-FROM debian
+FROM mirror.gcr.io/debian
 CMD /app/main.sh
 HEALTHCHECK   CMD   a b
 HEALTHCHECK --timeout=3s CMD ["foo"]

--- a/dockerclient/testdata/Dockerfile.healthcheck_defaults
+++ b/dockerclient/testdata/Dockerfile.healthcheck_defaults
@@ -1,3 +1,3 @@
-FROM debian
+FROM mirror.gcr.io/debian
 CMD /app/main.sh
 HEALTHCHECK CMD /app/check.sh --quiet

--- a/dockerclient/testdata/Dockerfile.mount
+++ b/dockerclient/testdata/Dockerfile.mount
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN stat -c "%s %n %a %F %g %u" /tmp/test/*

--- a/dockerclient/testdata/Dockerfile.multiarg
+++ b/dockerclient/testdata/Dockerfile.multiarg
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 ARG multivalarg="a=1 b=2 c=3 d=4"
 ENV multival="${multivalarg}"
 RUN echo $multival

--- a/dockerclient/testdata/Dockerfile.multistage
+++ b/dockerclient/testdata/Dockerfile.multistage
@@ -1,4 +1,4 @@
-FROM alpine as multistagebase
+FROM mirror.gcr.io/alpine as multistagebase
 COPY multistage/dir/a.txt /
 WORKDIR /tmp
 RUN touch /base.txt tmp.txt
@@ -7,17 +7,17 @@ FROM multistagebase as second
 COPY dir/file /
 RUN touch /second.txt
 
-FROM alpine
+FROM mirror.gcr.io/alpine
 COPY --from=1 /second.txt /third.txt
 
-FROM alpine
+FROM mirror.gcr.io/alpine
 COPY --from=2 /third.txt /fourth.txt
 
-FROM alpine
+FROM mirror.gcr.io/alpine
 COPY --from=multistagebase /base.txt /fifth.txt
 COPY --from=multistagebase ./tmp/tmp.txt /tmp.txt
-# "golang" has a default working directory of /go, and /go/src is a directory
-COPY --from=golang         go/src /src
+# "mirror.gcr.io/golang:1.24" has a default working directory of /go, and /go/src is a directory
+COPY --from=mirror.gcr.io/golang:1.24    go/src /src
 
 FROM multistagebase as final
 COPY copy/script /

--- a/dockerclient/testdata/Dockerfile.novolume
+++ b/dockerclient/testdata/Dockerfile.novolume
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN rm -fr /var/lib/not-in-this-image
 VOLUME /var/lib/not-in-this-image
 RUN mkdir -p /var/lib

--- a/dockerclient/testdata/Dockerfile.novolumenorun
+++ b/dockerclient/testdata/Dockerfile.novolumenorun
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN rm -fr /var/lib/not-in-this-image
 VOLUME /var/lib/not-in-this-image

--- a/dockerclient/testdata/Dockerfile.noworkdir
+++ b/dockerclient/testdata/Dockerfile.noworkdir
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 WORKDIR /foo
 VOLUME  [ "/foo" ]
 RUN echo

--- a/dockerclient/testdata/Dockerfile.reusebase
+++ b/dockerclient/testdata/Dockerfile.reusebase
@@ -1,4 +1,4 @@
-FROM centos:7 AS base
+FROM public.ecr.aws/docker/library/centos:7 AS base
 RUN touch /1
 ENV LOCAL=/1
 

--- a/dockerclient/testdata/Dockerfile.run.args
+++ b/dockerclient/testdata/Dockerfile.run.args
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN echo first second
 RUN /bin/echo third fourth
 RUN ["/bin/echo", "fifth", "sixth"]

--- a/dockerclient/testdata/Dockerfile.shell
+++ b/dockerclient/testdata/Dockerfile.shell
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 SHELL ["/bin/bash", "-xc"]
 RUN env

--- a/dockerclient/testdata/Dockerfile.target
+++ b/dockerclient/testdata/Dockerfile.target
@@ -3,11 +3,11 @@ ARG TARGET3=mytarget3
 FROM ubuntu:latest
 RUN touch /1
 
-FROM alpine:latest AS mytarget 
+FROM mirror.gcr.io/alpine:latest AS mytarget
 RUN touch /2
 
-FROM busybox:latest AS mytarget2 
+FROM mirror.gcr.io/busybox:latest AS mytarget2
 RUN touch /3
 
-FROM busybox:latest AS ${TARGET3}
+FROM mirror.gcr.io/busybox:latest AS ${TARGET3}
 RUN touch /4

--- a/dockerclient/testdata/Dockerfile.unknown
+++ b/dockerclient/testdata/Dockerfile.unknown
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 HEALTH NONE
 UNRECOGNIZED

--- a/dockerclient/testdata/Dockerfile.unset
+++ b/dockerclient/testdata/Dockerfile.unset
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ARG FOO
 ENV FOO=${FOO:?}

--- a/dockerclient/testdata/Dockerfile.volumeexists
+++ b/dockerclient/testdata/Dockerfile.volumeexists
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN mkdir -p 0700 /var/lib/bespoke-directory
 RUN chown 1:1 /var/lib/bespoke-directory
 VOLUME /var/lib/bespoke-directory

--- a/dockerclient/testdata/add/Dockerfile
+++ b/dockerclient/testdata/add/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 ADD archived.txt /archived.txt
 ADD archived.txt /archived/
 ADD archived.tar /archived.tar

--- a/dockerclient/testdata/add/Dockerfile.addall
+++ b/dockerclient/testdata/add/Dockerfile.addall
@@ -1,2 +1,2 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 ADD . .

--- a/dockerclient/testdata/add/Dockerfile.addslash
+++ b/dockerclient/testdata/add/Dockerfile.addslash
@@ -1,2 +1,2 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 ADD / /

--- a/dockerclient/testdata/add/Dockerfile.copy
+++ b/dockerclient/testdata/add/Dockerfile.copy
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY archived.txt /archived/
 COPY archived.txt /archived.txt
 COPY archived.tar /archived-tar/

--- a/dockerclient/testdata/builtins/Dockerfile
+++ b/dockerclient/testdata/builtins/Dockerfile
@@ -1,6 +1,6 @@
 ARG ALPINE
 
-FROM busybox
+FROM mirror.gcr.io/busybox
 RUN echo TARGETPLATFORM=$TARGETPLATFORM | tee 0.txt
 ARG TARGETPLATFORM
 RUN echo TARGETPLATFORM=$TARGETPLATFORM | tee -a 0.txt
@@ -17,18 +17,18 @@ ARG BUILDVARIANT
 RUN echo BUILDOS=$BUILDOS BUILDARCH=$BUILDARCH BUILDVARIANT=$BUILDVARIANT | tee -a 0.txt
 RUN touch -d @0 0.txt
 
-FROM ${SECONDBASE:-busybox}
+FROM ${SECONDBASE:-mirror.gcr.io/busybox}
 COPY --from=0 /*.txt /
 COPY --chown=${OWNERID:-1}:${OWNERID:-1} ${SOURCE:-other}file.txt /1a.txt
 ARG OWNERID=1
 ARG SOURCE=
 COPY --chown=${OWNERID:-1}:${OWNERID:-1} ${SOURCE:-other}file.txt /1b.txt
 
-FROM ${ALPINE:-busybox}
+FROM ${ALPINE:-mirror.gcr.io/busybox}
 ARG SECONDBASE=localhost/no-such-image
 COPY --from=1 /*.txt /
 RUN cp /etc/nsswitch.conf /2.txt
 
-FROM ${BUSYBOX:-alpine}
+FROM ${BUSYBOX:-mirror.gcr.io/alpine}
 COPY --from=2 /*.txt /
 RUN cp /etc/nsswitch.conf /3.txt

--- a/dockerclient/testdata/builtins/Dockerfile.margs
+++ b/dockerclient/testdata/builtins/Dockerfile.margs
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 ARG BUILDPLATFORM
 ARG BUILDOS
 ARG BUILDARCH
@@ -17,7 +17,7 @@ RUN echo ${TARGETOS}       > first/targetos=`echo ${TARGETOS} | sed s,/,_,g`
 RUN echo ${TARGETARCH}     > first/targetarch=`echo ${TARGETARCH} | sed s,/,_,g`
 RUN echo ${TARGETVARIANT}  > first/targetvariant=`echo ${TARGETVARIANT} | sed s,/,_,g`
 
-FROM alpine
+FROM mirror.gcr.io/alpine
 ARG BUILDPLATFORM
 ARG BUILDOS
 ARG BUILDARCH

--- a/dockerclient/testdata/copy/Dockerfile
+++ b/dockerclient/testdata/copy/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY script /usr/bin
 RUN ls -al /usr/bin/script

--- a/dockerclient/testdata/copyblahblub/Dockerfile
+++ b/dockerclient/testdata/copyblahblub/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY firstdir/seconddir /var
 RUN ls -la /var
 RUN ls -la /var/dir-a

--- a/dockerclient/testdata/copyblahblub/Dockerfile2
+++ b/dockerclient/testdata/copyblahblub/Dockerfile2
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY /firstdir/seconddir /var
 RUN ls -la /var
 RUN ls -la /var/dir-a

--- a/dockerclient/testdata/copyblahblub/Dockerfile3
+++ b/dockerclient/testdata/copyblahblub/Dockerfile3
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY /firstdir/seconddir/ /var
 RUN ls -la /var
 RUN ls -la /var/dir-a

--- a/dockerclient/testdata/copychmod/Dockerfile
+++ b/dockerclient/testdata/copychmod/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ADD --chown=0:0 --chmod=0755 file /
 ADD --chown=0:0 --chmod=644  file2 /
 ADD --chown=0:0 --chmod=7755 file3 /

--- a/dockerclient/testdata/copychown/Dockerfile
+++ b/dockerclient/testdata/copychown/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY --chown=1:2     script /usr/bin/script.12
 COPY --chown=1:adm   script /usr/bin/script.1-adm
 COPY --chown=1       script /usr/bin/script.1

--- a/dockerclient/testdata/copydir/Dockerfile
+++ b/dockerclient/testdata/copydir/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY dir /dir
 RUN ls -al /dir/file

--- a/dockerclient/testdata/copyempty/Dockerfile
+++ b/dockerclient/testdata/copyempty/Dockerfile
@@ -1,2 +1,2 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY "" /usr/local/tmp/

--- a/dockerclient/testdata/copyempty/Dockerfile2
+++ b/dockerclient/testdata/copyempty/Dockerfile2
@@ -1,2 +1,2 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY script1 "" script2 /usr/local/tmp/

--- a/dockerclient/testdata/copyfrom/Dockerfile
+++ b/dockerclient/testdata/copyfrom/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:7 as base
+FROM public.ecr.aws/docker/library/centos:7 as base
 RUN mkdir -p /a/blah && touch /a/blah/1 /a/blah/2
 RUN mkdir -m 711 /711 && touch /711/711.txt
 RUN mkdir -m 755 /755 && touch /755/755.txt
 RUN mkdir -m 777 /777 && touch /777/777.txt
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY --from=base /a/blah/* /blah/
 RUN rm -fr /711 /755 /777
 COPY --from=0 /711 /711

--- a/dockerclient/testdata/copyrename/Dockerfile
+++ b/dockerclient/testdata/copyrename/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 COPY file1 /usr/bin/file2
 RUN ls -al /usr/bin/file2 && ! ls -al /usr/bin/file1

--- a/dockerclient/testdata/dir/Dockerfile
+++ b/dockerclient/testdata/dir/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY . /
 COPY . dir
 COPY subdir/ test/

--- a/dockerclient/testdata/ignore/Dockerfile
+++ b/dockerclient/testdata/ignore/Dockerfile
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY . /

--- a/dockerclient/testdata/multistage/Dockerfile
+++ b/dockerclient/testdata/multistage/Dockerfile
@@ -1,14 +1,14 @@
-FROM golang:1.9 as builder
+FROM mirror.gcr.io/golang:1.24 as builder
 WORKDIR /tmp
 COPY . .
 RUN echo foo > /tmp/bar
 
-FROM busybox:latest AS modifier
+FROM mirror.gcr.io/busybox:latest AS modifier
 WORKDIR /tmp
 COPY --from=builder /tmp/bar /tmp/bar
 RUN echo foo2 >> /tmp/bar
 
-FROM busybox:latest
+FROM mirror.gcr.io/busybox:latest
 WORKDIR /
 COPY --from=modifier /tmp/bar /bin/baz
 COPY dir /var/dir

--- a/dockerclient/testdata/multistage/Dockerfile.arg-scope
+++ b/dockerclient/testdata/multistage/Dockerfile.arg-scope
@@ -1,10 +1,10 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 ARG SECRET
 ARG UNUSED
 ARG INHERITED=set
 RUN echo "$SECRET"
 
-FROM alpine
+FROM mirror.gcr.io/alpine
 ARG FOO=test
 ARG BAR=bartest
 RUN echo "$FOO:$BAR"

--- a/dockerclient/testdata/multistage/Dockerfile.env
+++ b/dockerclient/testdata/multistage/Dockerfile.env
@@ -1,6 +1,6 @@
 # Taken from #209
 
-FROM alpine AS base
+FROM mirror.gcr.io/alpine AS base
 ENV FOO=foo
 RUN echo FOO=$FOO
 

--- a/dockerclient/testdata/multistage/Dockerfile.heading-arg
+++ b/dockerclient/testdata/multistage/Dockerfile.heading-arg
@@ -1,12 +1,12 @@
-ARG GO_VERSION=1.9
-ARG GO_IMAGE=golang
+ARG GO_VERSION=1.24
+ARG GO_IMAGE=mirror.gcr.io/golang
 FROM $GO_IMAGE:$GO_VERSION as builder
 ARG FOO
 WORKDIR /tmp
 COPY . .
 RUN echo foo > /tmp/bar
 
-FROM busybox:latest AS modifier
+FROM mirror.gcr.io/busybox:latest AS modifier
 WORKDIR /tmp
 COPY --from=builder /tmp/bar /tmp/bar
 RUN echo foo2 >> /tmp/bar

--- a/dockerclient/testdata/multistage/Dockerfile.heading-redefine
+++ b/dockerclient/testdata/multistage/Dockerfile.heading-redefine
@@ -1,7 +1,7 @@
 ARG FOO=latest
-FROM alpine
+FROM mirror.gcr.io/alpine
 RUN echo "$FOO"
 
-FROM centos:$FOO
+FROM public.ecr.aws/centos:$FOO
 ARG FOO
 RUN echo "$FOO"

--- a/dockerclient/testdata/multistage/Dockerfile.ref
+++ b/dockerclient/testdata/multistage/Dockerfile.ref
@@ -1,6 +1,6 @@
-FROM busybox:latest
+FROM mirror.gcr.io/busybox:latest
 WORKDIR /
-COPY --from=nginx:latest /etc/nginx/nginx.conf /var/tmp/
+COPY --from=mirror.gcr.io/nginx:latest /etc/nginx/nginx.conf /var/tmp/
 COPY dir /var/dir
 RUN cat /var/tmp/nginx.conf
 

--- a/dockerclient/testdata/multistage/Dockerfile.relative-copy_1
+++ b/dockerclient/testdata/multistage/Dockerfile.relative-copy_1
@@ -1,7 +1,7 @@
-FROM busybox AS builder
+FROM mirror.gcr.io/busybox AS builder
 WORKDIR /usr
 RUN echo "test" > /usr/a.txt
 
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=builder ./a.txt /other/
 RUN ls /other/a.txt

--- a/dockerclient/testdata/multistage/Dockerfile.relative-copy_2
+++ b/dockerclient/testdata/multistage/Dockerfile.relative-copy_2
@@ -1,7 +1,7 @@
-FROM busybox AS builder
+FROM mirror.gcr.io/busybox AS builder
 WORKDIR /usr
 RUN echo "test" > /usr/a.txt
 
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY --from=builder ./a.txt /b.txt
 RUN ls /b.txt

--- a/dockerclient/testdata/overlapdir/Dockerfile.with_slash
+++ b/dockerclient/testdata/overlapdir/Dockerfile.with_slash
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY existing/ .

--- a/dockerclient/testdata/overlapdir/Dockerfile.without_slash
+++ b/dockerclient/testdata/overlapdir/Dockerfile.without_slash
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY existing .

--- a/dockerclient/testdata/singlefile/Dockerfile
+++ b/dockerclient/testdata/singlefile/Dockerfile
@@ -1,2 +1,2 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 COPY . copy

--- a/dockerclient/testdata/user-workdir/Dockerfile.notused
+++ b/dockerclient/testdata/user-workdir/Dockerfile.notused
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 RUN adduser -D buildtest
 USER buildtest
 WORKDIR /bin/created

--- a/dockerclient/testdata/user-workdir/Dockerfile.used
+++ b/dockerclient/testdata/user-workdir/Dockerfile.used
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 RUN adduser -D buildtest
 USER buildtest
 WORKDIR /bin/created

--- a/dockerclient/testdata/volume/Dockerfile
+++ b/dockerclient/testdata/volume/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ADD file /var/www/
 VOLUME /var/www

--- a/dockerclient/testdata/volumerun/Dockerfile
+++ b/dockerclient/testdata/volumerun/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ADD file /var/www/
 VOLUME /var/www

--- a/dockerclient/testdata/wildcard/Dockerfile
+++ b/dockerclient/testdata/wildcard/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 ENV DIR=/usr
 ADD dir2/*.b dir2/*.c $DIR/test/

--- a/dockerclient/testdata/workdir/Dockerfile.notrailing
+++ b/dockerclient/testdata/workdir/Dockerfile.notrailing
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 USER daemon
 WORKDIR /tmp

--- a/dockerclient/testdata/workdir/Dockerfile.trailing
+++ b/dockerclient/testdata/workdir/Dockerfile.trailing
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 USER daemon
 WORKDIR /tmp/

--- a/dockerfile/parser/parser_test.go
+++ b/dockerfile/parser/parser_test.go
@@ -142,7 +142,7 @@ func TestParseIncludesLineNumbers(t *testing.T) {
 
 func TestParseWarnsOnEmptyContinutationLine(t *testing.T) {
 	dockerfile := bytes.NewBufferString(`
-FROM alpine:3.6
+FROM mirror.gcr.io/alpine:3.6
 
 RUN something \
 

--- a/dockerfile/parser/testfiles-negative/env_no_value/Dockerfile
+++ b/dockerfile/parser/testfiles-negative/env_no_value/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 ENV PATH

--- a/dockerfile/parser/testfiles/continue-at-eof/Dockerfile
+++ b/dockerfile/parser/testfiles/continue-at-eof/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.5
+FROM mirror.gcr.io/alpine:3.5
 
 RUN something \

--- a/dockerfile/parser/testfiles/continue-at-eof/result
+++ b/dockerfile/parser/testfiles/continue-at-eof/result
@@ -1,2 +1,2 @@
-(from "alpine:3.5")
+(from "mirror.gcr.io/alpine:3.5")
 (run "something")

--- a/dockerfile/parser/testfiles/health/Dockerfile
+++ b/dockerfile/parser/testfiles/health/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM mirror.gcr.io/debian
 ADD check.sh main.sh /app/
 CMD /app/main.sh
 HEALTHCHECK

--- a/dockerfile/parser/testfiles/health/result
+++ b/dockerfile/parser/testfiles/health/result
@@ -1,4 +1,4 @@
-(from "debian")
+(from "mirror.gcr.io/debian")
 (add "check.sh" "main.sh" "/app/")
 (cmd "/app/main.sh")
 (healthcheck)

--- a/dockerfile/parser/testfiles/lk4d4-the-edge-case-generator/Dockerfile
+++ b/dockerfile/parser/testfiles/lk4d4-the-edge-case-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:buildroot-2014.02
+FROM mirror.gcr.io/busybox:buildroot-2014.02
 
 LABEL maintainer docker <docker@docker.io>
 

--- a/dockerfile/parser/testfiles/lk4d4-the-edge-case-generator/result
+++ b/dockerfile/parser/testfiles/lk4d4-the-edge-case-generator/result
@@ -1,4 +1,4 @@
-(from "busybox:buildroot-2014.02")
+(from "mirror.gcr.io/busybox:buildroot-2014.02")
 (label "maintainer" "docker <docker@docker.io>")
 (onbuild (run "echo" "test"))
 (onbuild (run "echo test"))


### PR DESCRIPTION
In tests that pull images, replace references to alpine, busybox, and centos:7 with references to mirror.gcr.io/alpine, mirror.gcr.io/busybox, and public.ecr.aws/docker/library/centos:7, respectively.  List the mirror.gcr.io/debian and mirror.gcr.io/golang:1.24 (formerly golang:1.9 in some places) images that we use in the conformance test doc, as well.

Update the `TestConformanceExternal/copy_and_env_interaction` conformance test to use a more recent Dockerfile from the git repository.