### PR TITLE
Tag v1.2.18

### DIFF
--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -34,7 +34,7 @@ func main() {
 	var version bool
 	var mountSpecs stringSliceFlag
 
-	VERSION := "1.2.18-dev"
+	VERSION := "1.2.18"
 	arguments := stringMapFlag{}
 
 	flag.Var(&tags, "t", "The name to assign this image, if any. May be specified multiple times.")

--- a/cmd/imagebuilder/imagebuilder.go
+++ b/cmd/imagebuilder/imagebuilder.go
@@ -34,7 +34,7 @@ func main() {
 	var version bool
 	var mountSpecs stringSliceFlag
 
-	VERSION := "1.2.18"
+	VERSION := "1.2.19-dev"
 	arguments := stringMapFlag{}
 
 	flag.Var(&tags, "t", "The name to assign this image, if any. May be specified multiple times.")

--- a/imagebuilder.spec
+++ b/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.19
-%{!?version: %global version 1.2.18}
+%{!?version: %global version 1.2.19-dev}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/imagebuilder.spec
+++ b/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.19
-%{!?version: %global version 1.2.18-dev}
+%{!?version: %global version 1.2.18}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder


### PR DESCRIPTION
Tag a v1.2.18 release, mainly to incorporate #308, but also picking up #309.