### PR TITLE
When stages have duplicate nicknames, make the last one win

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -213,7 +213,7 @@ var (
 type Stages []Stage
 
 func (stages Stages) ByName(name string) (Stage, bool) {
-	for _, stage := range stages {
+	for _, stage := range slices.Backward(stages) {
 		if stage.Name == name {
 			return stage, true
 		}
@@ -241,7 +241,7 @@ func (stages Stages) ByTarget(target string) (Stages, bool) {
 	if len(target) == 0 {
 		return stages, true
 	}
-	for i, stage := range stages {
+	for i, stage := range slices.Backward(stages) {
 		if stage.Name == target {
 			return stages[i : i+1], true
 		}
@@ -264,7 +264,7 @@ func (stages Stages) ThroughTarget(target string) (Stages, bool) {
 	if len(target) == 0 {
 		return stages, true
 	}
-	for i, stage := range stages {
+	for i, stage := range slices.Backward(stages) {
 		if stage.Name == target {
 			return stages[0 : i+1], true
 		}
@@ -284,7 +284,7 @@ func (stages Stages) ThroughTarget(target string) (Stages, bool) {
 
 type Stage struct {
 	Position int
-	Name     string
+	Name     string // may just be strconv.Itoa(Position), be sure to search from back to front
 	Builder  *Builder
 	Node     *parser.Node
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -72,6 +72,101 @@ func TestVolumeSet(t *testing.T) {
 	}
 }
 
+func TestByName(t *testing.T) {
+	n, err := ParseFile("dockerclient/testdata/Dockerfile.target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stages, err := NewStages(n, NewBuilder(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 4 {
+		t.Fatalf("expected 4 stages, got %d", len(stages))
+	}
+	t.Logf("stages: %#v", stages)
+
+	stage1, found := stages.ByName("mytarget")
+	if !found {
+		t.Fatal("First target not found")
+	}
+	if stage1.Position != 1 {
+		t.Fatalf("expected stage at position 1, got %d", stage1.Position)
+	}
+	t.Logf("stage1: %#v", stage1)
+
+	stage2, found := stages.ByName("mytarget2")
+	if !found {
+		t.Fatal("Second target not found")
+	}
+	if stage2.Position != 2 {
+		t.Fatalf("expected stage at position 2, got %d", stage1.Position)
+	}
+	t.Logf("stage2: %#v", stage2)
+
+	stage3, found := stages.ByName("1")
+	if !found {
+		t.Fatal("Third target not found")
+	}
+	if stage3.Position != 1 {
+		t.Fatalf("expected stage at position 1, got %d", stage3.Position)
+	}
+	t.Logf("stage3: %#v", stage3)
+	assert.Equal(t, stage3, stage1)
+
+	stage4, found := stages.ByName("2")
+	if !found {
+		t.Fatal("Fourth target not found")
+	}
+	if stage4.Position != 2 {
+		t.Fatalf("expected stage at position 2, got %d", stage4.Position)
+	}
+	t.Logf("stage4: %#v", stage4)
+	assert.Equal(t, stage4, stage2)
+
+	stage5, found := stages.ByName("mytarget3")
+	if !found {
+		t.Fatal("Fifth target not found")
+	}
+	if stage5.Position != 3 {
+		t.Fatalf("expected stage at position 3, got %d", stage5.Position)
+	}
+	t.Logf("stage5: %#v", stage5)
+
+	stage6, found := stages.ByName("3")
+	if !found {
+		t.Fatal("Sixth target not found")
+	}
+	if stage6.Position != 3 {
+		t.Fatalf("expected stage at position 3, got %d", stage6.Position)
+	}
+	t.Logf("stage6: %#v", stage6)
+	assert.Equal(t, stage6, stage5)
+
+	n, err = ParseFile("dockerclient/testdata/Dockerfile.target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stages, err = NewStages(n, NewBuilder(map[string]string{"TARGET3": "mytarget"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 4 {
+		t.Fatalf("expected 4 stage, got %d", len(stages))
+	}
+	t.Logf("stages: %#v", stages)
+
+	stage7, found := stages.ByName("mytarget")
+	if !found {
+		t.Fatal("Seventh target not found")
+	}
+	if stage7.Position != 3 {
+		t.Fatalf("expected stage at position 3, got %d", stage7.Position)
+	}
+	t.Logf("stage7: %#v", stage7)
+
+}
+
 func TestByTarget(t *testing.T) {
 	n, err := ParseFile("dockerclient/testdata/Dockerfile.target")
 	if err != nil {
@@ -92,6 +187,9 @@ func TestByTarget(t *testing.T) {
 	}
 	if len(stages1) != 1 {
 		t.Fatalf("expected 1 stages, got %d", len(stages1))
+	}
+	if stages1[0].Position != 1 {
+		t.Fatalf("expected stage at position 1, got %d", stages1[0].Position)
 	}
 	t.Logf("stages1: %#v", stages1)
 
@@ -138,10 +236,36 @@ func TestByTarget(t *testing.T) {
 		t.Fatal("Sixth target not found")
 	}
 	if len(stages6) != 1 {
-		t.Fatalf("expected 1 stages, got %d", len(stages4))
+		t.Fatalf("expected 1 stages, got %d", len(stages6))
 	}
 	t.Logf("stages6: %#v", stages6)
 	assert.Equal(t, stages6, stages5)
+
+	n, err = ParseFile("dockerclient/testdata/Dockerfile.target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stages, err = NewStages(n, NewBuilder(map[string]string{"TARGET3": "mytarget"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 4 {
+		t.Fatalf("expected 4 stages, got %d", len(stages))
+	}
+	t.Logf("stages: %#v", stages)
+
+	stages7, found := stages.ByTarget("mytarget")
+	if !found {
+		t.Fatal("Seventh target not found")
+	}
+	if len(stages7) != 1 {
+		t.Fatalf("expected 1 stages, got %d", len(stages7))
+	}
+	if stages7[0].Position != 3 {
+		t.Fatalf("expected stage at position 3, got %d", stages7[0].Position)
+	}
+	t.Logf("stages7: %#v", stages7)
+
 }
 
 func TestThroughTarget(t *testing.T) {
@@ -214,6 +338,29 @@ func TestThroughTarget(t *testing.T) {
 	}
 	t.Logf("stages6: %#v", stages6)
 	assert.Equal(t, stages6, stages5)
+
+	n, err = ParseFile("dockerclient/testdata/Dockerfile.target")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stages, err = NewStages(n, NewBuilder(map[string]string{"TARGET3": "mytarget"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 4 {
+		t.Fatalf("expected 4 stages, got %d", len(stages))
+	}
+	t.Logf("stages: %#v", stages)
+
+	stages7, found := stages.ThroughTarget("mytarget")
+	if !found {
+		t.Fatal("Seventh target not found")
+	}
+	if len(stages7) != 4 {
+		t.Fatalf("expected 4 stages, got %d", len(stages7))
+	}
+	t.Logf("stages7: %#v", stages7)
 }
 
 func TestMultiStageParse(t *testing.T) {

--- a/dockerclient/client.go
+++ b/dockerclient/client.go
@@ -195,7 +195,7 @@ func (e *ClientExecutor) Stages(b *imagebuilder.Builder, stages imagebuilder.Sta
 				return nil, fmt.Errorf("the --after flag in FROM is not supported by the dockerclient executor")
 			}
 			if prereq := e.Named[from]; prereq != nil {
-				b, ok := stages.ByName(from)
+				b, ok := stages[:i].ByName(from)
 				if !ok {
 					return nil, fmt.Errorf("error: Unable to find stage %s builder", from)
 				}

--- a/dockerclient/conformance_test.go
+++ b/dockerclient/conformance_test.go
@@ -505,6 +505,12 @@ func TestConformanceInternal(t *testing.T) {
 			Dockerfile: "testdata/builtins/Dockerfile.margs",
 		},
 		{
+			Name:       "duplicate-stage",
+			Version:    docker.BuilderBuildKit,
+			ContextDir: "testdata/multistage",
+			Dockerfile: "Dockerfile.dupstage",
+		},
+		{
 			Name:       "header-builtin",
 			Version:    docker.BuilderBuildKit,
 			ContextDir: "testdata/header-builtin",

--- a/dockerclient/testdata/multistage/Dockerfile.dupstage
+++ b/dockerclient/testdata/multistage/Dockerfile.dupstage
@@ -1,0 +1,9 @@
+FROM mirror.gcr.io/busybox AS stage0
+COPY --chown=0:0 stage0.txt /stage.txt
+LABEL x="really stage 0"
+
+FROM mirror.gcr.io/busybox AS stage0
+COPY --chown=0:0 stage1.txt /stage.txt
+LABEL x="really stage 1"
+
+FROM stage0

--- a/dockerclient/testdata/multistage/stage0.txt
+++ b/dockerclient/testdata/multistage/stage0.txt
@@ -1,0 +1,1 @@
+really stage 0

--- a/dockerclient/testdata/multistage/stage1.txt
+++ b/dockerclient/testdata/multistage/stage1.txt
@@ -1,0 +1,1 @@
+really stage 1


### PR DESCRIPTION
When multiple stages all have the same nickname, when we attempt to resolve a name to a stage, choose the latest one possible.